### PR TITLE
Fix syntax in the example

### DIFF
--- a/examples/invaders/main.rs
+++ b/examples/invaders/main.rs
@@ -95,7 +95,7 @@ fn main() -> Result<(), Error> {
 fn create_window(
     title: &str,
     event_loop: &EventLoop<()>,
-) -> (winit::window::Window, wgpu::Surface, u32, u32, f64) {
+) -> (winit::window::Window, pixels::wgpu::Surface, u32, u32, f64) {
     // Create a hidden window so we can estimate a good default window size
     let window = winit::window::WindowBuilder::new()
         .with_visible(false)


### PR DESCRIPTION
- This works because `wgpu` is a dependency for `pixels`
- But this example should be demonstrating how to ony depend on `pixels` ... And whatever windowing system and event-loop you might want.