### PR TITLE
Reorganize dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ winit-deps = ["winit", "winit_input_helper"]
 
 conway = ["line_drawing", "log-deps", "random-deps", "winit-deps"]
 invaders = ["gilrs", "log-deps", "random-deps", "simple-invaders", "winit-deps"]
-minimal-winit = ["winit-deps"]
+minimal-winit = ["log-deps", "winit-deps"]
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,18 +25,44 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 wgpu = "0.4"
 
+# These are only used by the examples, and enabled with features
+# See: https://github.com/rust-lang/cargo/issues/1982
+byteorder = { version = "1.3", optional = true }
+env_logger = { version = "0.7", optional = true }
+getrandom = { version = "0.1", optional = true }
+gilrs = { version = "0.7", optional = true }
+line_drawing = { version = "0.8", optional = true }
+log = { version = "0.4", features = ["release_max_level_warn"], optional = true }
+randomize = { version = "3.0", optional = true }
+simple-invaders = { path = "simple-invaders", optional = true }
+winit = { version = "0.20.0-alpha4", optional = true }
+winit_input_helper = { version = "0.4.0-alpha4", optional = true }
+
 [dev-dependencies]
-byteorder = "1.3"
-env_logger = "0.7"
-getrandom = "0.1"
-gilrs = "0.7"
-line_drawing = "0.8"
-log = { version = "0.4", features = ["release_max_level_warn"] }
 pixels-mocks = { path = "pixels-mocks" }
-randomize = "3.0"
-simple-invaders = { path = "simple-invaders" }
 winit = "0.20.0-alpha4"
-winit_input_helper = "0.4.0-alpha4"
+
+[[example]]
+name = "conway"
+required-features = ["conway"]
+
+[[example]]
+name = "invaders"
+required-features = ["invaders"]
+
+[[example]]
+name = "minimal-winit"
+required-features = ["minimal-winit"]
+
+[features]
+default = []
+log-deps = ["env_logger", "log"]
+random-deps = ["byteorder", "getrandom", "randomize"]
+winit-deps = ["winit", "winit_input_helper"]
+
+conway = ["line_drawing", "log-deps", "random-deps", "winit-deps"]
+invaders = ["gilrs", "log-deps", "random-deps", "simple-invaders", "winit-deps"]
+minimal-winit = ["winit-deps"]
 
 [workspace]
 members = [

--- a/examples/conway/README.md
+++ b/examples/conway/README.md
@@ -5,7 +5,7 @@
 ## Running
 
 ```bash
-cargo run --release --example conway
+cargo run --release --example conway --features conway
 ```
 
 ## Controls

--- a/examples/invaders/README.md
+++ b/examples/invaders/README.md
@@ -7,7 +7,7 @@ The pixels have invaded!
 ## Running
 
 ```bash
-cargo run --release --example invaders
+cargo run --release --example invaders --features invaders
 ```
 
 ## Controls

--- a/examples/minimal-winit/README.md
+++ b/examples/minimal-winit/README.md
@@ -7,7 +7,7 @@ Minimal example with `winit`.
 ## Running
 
 ```bash
-cargo run --release --example minimal-winit
+cargo run --release --example minimal-winit --features minimal-winit
 ```
 
 ## About

--- a/examples/minimal-winit/main.rs
+++ b/examples/minimal-winit/main.rs
@@ -95,10 +95,10 @@ impl World {
 
     /// Update the `World` internal state; bounce the box around the screen.
     fn update(&mut self) {
-        if self.box_x < 0 || self.box_x + BOX_SIZE >= WIDTH as i16 {
+        if self.box_x <= 0 || self.box_x + BOX_SIZE - 1 >= WIDTH as i16 {
             self.velocity_x *= -1;
         }
-        if self.box_y < 0 || self.box_y + BOX_SIZE >= HEIGHT as i16 {
+        if self.box_y <= 0 || self.box_y + BOX_SIZE - 1 >= HEIGHT as i16 {
             self.velocity_y *= -1;
         }
 

--- a/examples/minimal-winit/main.rs
+++ b/examples/minimal-winit/main.rs
@@ -21,6 +21,7 @@ struct World {
 }
 
 fn main() -> Result<(), Error> {
+    env_logger::init();
     let event_loop = EventLoop::new();
     let mut input = WinitInputHelper::new();
     let window = {


### PR DESCRIPTION
See: https://github.com/rust-lang/cargo/issues/1982

I ran into a problem when trying to add a minimal example for SDL2. The dependency will not build unless SDL2 is installed on the system. It is only required for examples that need SDL2, but running any example will compile _all_ `dev-dependencies`. Whoops! That would create a hard dependency on `SDL2` for anyone who wants to run the examples.

Similarly for any example; e.g. the `line_drawing` crate is compiled for every example, but it's only used by `conway`.

This PR addresses the shortcoming in Cargo by exploiting `required-features` on each example. It makes the commands slightly longer, since the feature must be explicitly enabled. But it works around the issue.

----

There was a much bigger problem that I ran into with SDL2. It supports OpenGL, but 1) I couldn't get a handle to the surface after converting the window into a [`GLWindow`](https://docs.rs/beryllium/0.1.2/beryllium/struct.GLWindow.html) (this looks like a `beryllium` bug; the `GLWindow` does not implement `raw-window-handle`), and 2) `wgpu` 0.4 does not support OpenGL anyway. Oh well! I could have attempted to use Vulkan, and maybe my next attempt will be exactly that.