### PR TITLE
treewide: update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 rust:
 # MSRV
-- 1.36.0
+- 1.40.0
 
 # Stable release channel
 - stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,26 +23,27 @@ travis-ci = { repository = "parasyte/pixels" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-thiserror = "1.0"
-wgpu = "0.4"
+thiserror = "1.0.15"
+wgpu = "0.5.0"
+futures = "0.3"
 
 # These are only used by the examples, and enabled with features
 # See: https://github.com/rust-lang/cargo/issues/1982
-beryllium = { version = " 0.1", optional = true }
-byteorder = { version = "1.3", optional = true }
-env_logger = { version = "0.7", optional = true }
-getrandom = { version = "0.1", optional = true }
-gilrs = { version = "0.7", optional = true }
-line_drawing = { version = "0.8", optional = true }
-log = { version = "0.4", features = ["release_max_level_warn"], optional = true }
-randomize = { version = "3.0", optional = true }
+beryllium = { version = "0.2.1", features = [ "extern_crate_raw_window_handle" ], optional = true }
+byteorder = { version = "1.3.4", optional = true }
+env_logger = { version = "0.7.1", optional = true }
+getrandom = { version = "0.1.14", optional = true }
+gilrs = { version = "0.7.4", optional = true }
+line_drawing = { version = "0.8.0", optional = true }
+log = { version = "0.4.8", features = [ "release_max_level_warn" ], optional = true }
+randomize = { version = "3.0.1", optional = true }
 simple-invaders = { path = "simple-invaders", optional = true }
-winit = { version = "=0.20.0-alpha4", optional = true }
-winit_input_helper = { version = "=0.4.0-alpha4", optional = true }
+winit = { version = "0.22.0", optional = true }
+winit_input_helper = { version = "0.6.0", optional = true }
 
 [dev-dependencies]
 pixels-mocks = { path = "pixels-mocks" }
-winit = "=0.20.0-alpha4"
+winit = "0.22.0"
 
 [[example]]
 name = "conway"

--- a/examples/conway/main.rs
+++ b/examples/conway/main.rs
@@ -4,7 +4,7 @@
 use log::debug;
 use pixels::{Error, Pixels, SurfaceTexture};
 use winit::dpi::{LogicalPosition, LogicalSize, PhysicalSize};
-use winit::event::{Event, VirtualKeyCode, WindowEvent};
+use winit::event::{Event, VirtualKeyCode};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit_input_helper::WinitInputHelper;
 
@@ -15,7 +15,7 @@ fn main() -> Result<(), Error> {
     env_logger::init();
     let event_loop = EventLoop::new();
     let mut input = WinitInputHelper::new();
-    let (window, surface, mut p_width, mut p_height, mut hidpi_factor) =
+    let (window, surface, p_width, p_height, mut hidpi_factor) =
         create_window("Conway's Game of Life", &event_loop);
 
     let surface_texture = SurfaceTexture::new(p_width, p_height, surface);
@@ -28,13 +28,9 @@ fn main() -> Result<(), Error> {
 
     event_loop.run(move |event, _, control_flow| {
         // The one and only event that winit_input_helper doesn't have for us...
-        if let Event::WindowEvent {
-            event: WindowEvent::RedrawRequested,
-            ..
-        } = event
-        {
+        if let Event::RedrawRequested(_) = event {
             life.draw(pixels.get_frame());
-            pixels.render();
+            pixels.render().unwrap();
         }
 
         // For everything else, for let winit_input_helper collect events to build its state.
@@ -100,15 +96,12 @@ fn main() -> Result<(), Error> {
                 }
             }
             // Adjust high DPI factor
-            if let Some(factor) = input.hidpi_changed() {
+            if let Some(factor) = input.scale_factor_changed() {
                 hidpi_factor = factor;
             }
             // Resize the window
             if let Some(size) = input.window_resized() {
-                let size = size.to_physical(hidpi_factor);
-                p_width = size.width.round() as u32;
-                p_height = size.height.round() as u32;
-                pixels.resize(p_width, p_height);
+                pixels.resize(size.width, size.height);
             }
             if !paused || input.key_pressed(VirtualKeyCode::Space) {
                 life.update();
@@ -138,19 +131,23 @@ fn create_window(
         .with_title(title)
         .build(&event_loop)
         .unwrap();
-    let hidpi_factor = window.hidpi_factor();
+    let hidpi_factor = window.scale_factor();
 
     // Get dimensions
     let width = SCREEN_WIDTH as f64;
     let height = SCREEN_HEIGHT as f64;
     let (monitor_width, monitor_height) = {
         let size = window.current_monitor().size();
-        (size.width / hidpi_factor, size.height / hidpi_factor)
+        (
+            size.width as f64 / hidpi_factor,
+            size.height as f64 / hidpi_factor,
+        )
     };
     let scale = (monitor_height / height * 2.0 / 3.0).round();
 
     // Resize, center, and display the window
-    let min_size = PhysicalSize::new(width, height).to_logical(hidpi_factor);
+    let min_size: winit::dpi::LogicalSize<f64> =
+        PhysicalSize::new(width, height).to_logical(hidpi_factor);
     let default_size = LogicalSize::new(width * scale, height * scale);
     let center = LogicalPosition::new(
         (monitor_width - width * scale) / 2.0,
@@ -162,7 +159,7 @@ fn create_window(
     window.set_visible(true);
 
     let surface = pixels::wgpu::Surface::create(&window);
-    let size = default_size.to_physical(hidpi_factor);
+    let size = default_size.to_physical::<f64>(hidpi_factor);
 
     (
         window,
@@ -302,14 +299,14 @@ impl ConwayGrid {
         } else {
             (y - 1, y + 1)
         };
-        (self.cells[xm1 + ym1 * self.width].alive as usize
+        self.cells[xm1 + ym1 * self.width].alive as usize
             + self.cells[x + ym1 * self.width].alive as usize
             + self.cells[xp1 + ym1 * self.width].alive as usize
             + self.cells[xm1 + y * self.width].alive as usize
             + self.cells[xp1 + y * self.width].alive as usize
             + self.cells[xm1 + yp1 * self.width].alive as usize
             + self.cells[x + yp1 * self.width].alive as usize
-            + self.cells[xp1 + yp1 * self.width].alive as usize)
+            + self.cells[xp1 + yp1 * self.width].alive as usize
     }
 
     fn update(&mut self) {

--- a/examples/minimal-winit/main.rs
+++ b/examples/minimal-winit/main.rs
@@ -3,7 +3,7 @@
 
 use pixels::{wgpu::Surface, Error, Pixels, SurfaceTexture};
 use winit::dpi::LogicalSize;
-use winit::event::{Event, VirtualKeyCode, WindowEvent};
+use winit::event::{Event, VirtualKeyCode};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::window::WindowBuilder;
 use winit_input_helper::WinitInputHelper;
@@ -33,7 +33,7 @@ fn main() -> Result<(), Error> {
             .build(&event_loop)
             .unwrap()
     };
-    let mut hidpi_factor = window.hidpi_factor();
+    let mut hidpi_factor = window.scale_factor();
 
     let mut pixels = {
         let surface = Surface::create(&window);
@@ -44,13 +44,9 @@ fn main() -> Result<(), Error> {
 
     event_loop.run(move |event, _, control_flow| {
         // Draw the current frame
-        if let Event::WindowEvent {
-            event: WindowEvent::RedrawRequested,
-            ..
-        } = event
-        {
+        if let Event::RedrawRequested(_) = event {
             world.draw(pixels.get_frame());
-            pixels.render();
+            pixels.render().unwrap();
         }
 
         // Handle input events
@@ -62,17 +58,13 @@ fn main() -> Result<(), Error> {
             }
 
             // Adjust high DPI factor
-            if let Some(factor) = input.hidpi_changed() {
+            if let Some(factor) = input.scale_factor_changed() {
                 hidpi_factor = factor;
             }
 
             // Resize the window
             if let Some(size) = input.window_resized() {
-                let size = size.to_physical(hidpi_factor);
-                let width = size.width.round() as u32;
-                let height = size.height.round() as u32;
-
-                pixels.resize(width, height);
+                pixels.resize(size.width, size.height);
             }
 
             // Update internal state and request a redraw


### PR DESCRIPTION
This updates all of `pixels`'s dependencies. Most importantly, it gets us winit 0.22 and wgpu 0.5.0.

This was done in a best-effort way, as I sometimes wasn't entire sure how to get things to work. There's a nasty transmute I want to get rid off, but couldn't figure out how. Figured I'd open the PR to get some ideas.