### PR TITLE
cargo: remove features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,51 +26,19 @@ maintenance = { status = "actively-developed" }
 thiserror = "1.0"
 wgpu = "0.4"
 
-# These are only used by the examples, and enabled with features
-# See: https://github.com/rust-lang/cargo/issues/1982
-beryllium = { version = " 0.1", optional = true }
-byteorder = { version = "1.3", optional = true }
-env_logger = { version = "0.7", optional = true }
-getrandom = { version = "0.1", optional = true }
-gilrs = { version = "0.7", optional = true }
-line_drawing = { version = "0.8", optional = true }
-log = { version = "0.4", features = ["release_max_level_warn"], optional = true }
-randomize = { version = "3.0", optional = true }
-simple-invaders = { path = "simple-invaders", optional = true }
-winit = { version = "=0.20.0-alpha4", optional = true }
-winit_input_helper = { version = "=0.4.0-alpha4", optional = true }
-
 [dev-dependencies]
+beryllium = "0.1"
+byteorder = "1.3"
+env_logger = "0.7"
+getrandom ="0.1"
+gilrs = "0.7"
+line_drawing ="0.8"
+log = { version = "0.4", features = ["release_max_level_warn"]}
 pixels-mocks = { path = "pixels-mocks" }
+randomize = "3.0"
+simple-invaders = { path = "simple-invaders" }
 winit = "=0.20.0-alpha4"
-
-[[example]]
-name = "conway"
-required-features = ["conway"]
-
-[[example]]
-name = "invaders"
-required-features = ["invaders"]
-
-[[example]]
-name = "minimal-sdl2"
-required-features = ["minimal-sdl2"]
-
-[[example]]
-name = "minimal-winit"
-required-features = ["minimal-winit"]
-
-[features]
-default = []
-log-deps = ["env_logger", "log"]
-random-deps = ["byteorder", "getrandom", "randomize"]
-sdl2-deps = ["beryllium"]
-winit-deps = ["winit", "winit_input_helper"]
-
-conway = ["line_drawing", "log-deps", "random-deps", "winit-deps"]
-invaders = ["gilrs", "log-deps", "random-deps", "simple-invaders", "winit-deps"]
-minimal-sdl2 = ["log-deps", "sdl2-deps"]
-minimal-winit = ["log-deps", "winit-deps"]
+winit_input_helper = "=0.4.0-alpha4"
 
 [workspace]
 members = [


### PR DESCRIPTION
The justification for them existing was that cargo adds in binary-only
deps to mixed bin/lib crates, which inflates dependency trees and
overall just sucks.

While this is true, that doesn't apply to dev-dependencies, which don't
get propagated, but which are available to example code. By removing the
myriad of features and moving those dependencies into `dev-dependencies`
we make developers' lives easier (it's easier to run examples) and don't
actually lose anything.

Moreover, this also allows to test all code with no need for
`--all-features`.