### PR TITLE
Add a badge for github-actions status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Documentation](https://docs.rs/pixels/badge.svg)](https://docs.rs/pixels)
 [![Build Status](https://travis-ci.org/parasyte/pixels.svg?branch=master)](https://travis-ci.org/parasyte/pixels)
+[![CI](https://github.com/parasyte/pixels/workflows/CI/badge.svg)](https://github.com/parasyte/pixels)
 [![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 
 ![Pixels Logo](img/pixels.png)


### PR DESCRIPTION
- I would like to add a badge to the Cargo manifest too, but it's currently WIP: https://github.com/rust-lang/crates.io/pull/1838