### PR TITLE
Slim dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 thiserror = "1.0.15"
 wgpu = "0.5.0"
-futures = "0.3"
+futures-executor = "0.3"
 
 [dev-dependencies]
 pixels-mocks = { path = "pixels-mocks" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -426,13 +426,13 @@ impl<'req> PixelsBuilder<'req> {
     /// Returns an error when a [`wgpu::Adapter`] cannot be found.
     pub fn build(self) -> Result<Pixels, Error> {
         // TODO: Use `options.pixel_aspect_ratio` to stretch the scaled texture
-        let adapter = futures::executor::block_on(wgpu::Adapter::request(
+        let adapter = futures_executor::block_on(wgpu::Adapter::request(
             &self.request_adapter_options,
             wgpu::BackendBit::PRIMARY,
         ))
         .ok_or(Error::AdapterNotFound)?;
         let (device, queue) =
-            futures::executor::block_on(adapter.request_device(&self.device_descriptor));
+            futures_executor::block_on(adapter.request_device(&self.device_descriptor));
         let device = Rc::new(device);
         let queue = Rc::new(RefCell::new(queue));
 


### PR DESCRIPTION
This removes some unnecessary dependencies from the `futures` tree.

Before:

```
$ cargo tree
pixels v0.0.3 (/Users/parasyte/projects/pixels)
├── futures v0.3.4
│   ├── futures-channel v0.3.4
│   │   ├── futures-core v0.3.4
│   │   └── futures-sink v0.3.4
│   ├── futures-core v0.3.4 (*)
│   ├── futures-executor v0.3.4
│   │   ├── futures-core v0.3.4 (*)
│   │   ├── futures-task v0.3.4
│   │   └── futures-util v0.3.4
│   │       ├── futures-channel v0.3.4 (*)
│   │       ├── futures-core v0.3.4 (*)
│   │       ├── futures-io v0.3.4
│   │       ├── futures-macro v0.3.4
│   │       │   ├── proc-macro-hack v0.5.15
│   │       │   ├── proc-macro2 v1.0.10
│   │       │   │   └── unicode-xid v0.2.0
│   │       │   ├── quote v1.0.3
│   │       │   │   └── proc-macro2 v1.0.10 (*)
│   │       │   └── syn v1.0.17
│   │       │       ├── proc-macro2 v1.0.10 (*)
│   │       │       ├── quote v1.0.3 (*)
│   │       │       └── unicode-xid v0.2.0 (*)
│   │       ├── futures-sink v0.3.4 (*)
│   │       ├── futures-task v0.3.4 (*)
│   │       ├── memchr v2.3.3
│   │       ├── pin-utils v0.1.0-alpha.4
│   │       ├── proc-macro-hack v0.5.15 (*)
│   │       ├── proc-macro-nested v0.1.4
│   │       └── slab v0.4.2
│   ├── futures-io v0.3.4 (*)
│   ├── futures-sink v0.3.4 (*)
│   ├── futures-task v0.3.4 (*)
│   └── futures-util v0.3.4 (*)
```

After:

```
$ cargo tree
pixels v0.0.3 (/Users/parasyte/projects/pixels)
├── futures-executor v0.3.4
│   ├── futures-core v0.3.4
│   ├── futures-task v0.3.4
│   └── futures-util v0.3.4
│       ├── futures-core v0.3.4 (*)
│       ├── futures-task v0.3.4 (*)
│       ├── pin-utils v0.1.0-alpha.4
│       └── slab v0.4.2
```