### PR TITLE
Add a method to convert cursor coords to pixel coords

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ include = [
 thiserror = "1.0.15"
 wgpu = "0.5.0"
 futures-executor = "0.3"
+ultraviolet = "0.4.6"
 
 [dev-dependencies]
 pixels-mocks = { path = "pixels-mocks" }

--- a/examples/conway/src/main.rs
+++ b/examples/conway/src/main.rs
@@ -68,22 +68,12 @@ fn main() -> Result<(), Error> {
                     let prev_y = my - dy;
 
                     let (mx_i, my_i) = pixels
-                        .window_pos_to_pixel((mx as f64, my as f64))
-                        .unwrap_or_else(|(x, y)| {
-                            (
-                                x.max(0).min(SCREEN_WIDTH as isize - 1) as usize,
-                                y.max(0).min(SCREEN_HEIGHT as isize - 1) as usize,
-                            )
-                        });
+                        .window_pos_to_pixel((mx, my))
+                        .unwrap_or_else(|pos| pixels.clamp_pixel_pos(pos));
 
                     let (px_i, py_i) = pixels
-                        .window_pos_to_pixel((prev_x as f64, prev_y as f64))
-                        .unwrap_or_else(|(x, y)| {
-                            (
-                                x.max(0).min(SCREEN_WIDTH as isize - 1) as usize,
-                                y.max(0).min(SCREEN_HEIGHT as isize - 1) as usize,
-                            )
-                        });
+                        .window_pos_to_pixel((prev_x, prev_y))
+                        .unwrap_or_else(|pos| pixels.clamp_pixel_pos(pos));
 
                     (
                         (mx_i as isize, my_i as isize),

--- a/examples/conway/src/main.rs
+++ b/examples/conway/src/main.rs
@@ -66,13 +66,13 @@ fn main() -> Result<(), Error> {
                     let (dx, dy) = input.mouse_diff();
                     let prev_x = mx - dx;
                     let prev_y = my - dy;
-                    let dpx = hidpi_factor as f32;
-                    let (w, h) = (p_width as f32 / dpx, p_height as f32 / dpx);
-                    let mx_i = ((mx / w) * (SCREEN_WIDTH as f32)).round() as isize;
-                    let my_i = ((my / h) * (SCREEN_HEIGHT as f32)).round() as isize;
-                    let px_i = ((prev_x / w) * (SCREEN_WIDTH as f32)).round() as isize;
-                    let py_i = ((prev_y / h) * (SCREEN_HEIGHT as f32)).round() as isize;
-                    ((mx_i, my_i), (px_i, py_i))
+                    
+                    let (mx_i, my_i) = pixels.window_pos_to_pixel((mx as f64, my as f64));
+                    let (px_i, py_i) = pixels.window_pos_to_pixel((prev_x as f64, prev_y as f64));
+                    (
+                        (mx_i as isize, my_i as isize),
+                        (px_i as isize, py_i as isize),
+                    )
                 })
                 .unwrap_or_default();
 

--- a/examples/conway/src/main.rs
+++ b/examples/conway/src/main.rs
@@ -66,7 +66,7 @@ fn main() -> Result<(), Error> {
                     let (dx, dy) = input.mouse_diff();
                     let prev_x = mx - dx;
                     let prev_y = my - dy;
-                    
+
                     let (mx_i, my_i) = pixels.window_pos_to_pixel((mx as f64, my as f64));
                     let (px_i, py_i) = pixels.window_pos_to_pixel((prev_x as f64, prev_y as f64));
                     (

--- a/examples/conway/src/main.rs
+++ b/examples/conway/src/main.rs
@@ -67,8 +67,24 @@ fn main() -> Result<(), Error> {
                     let prev_x = mx - dx;
                     let prev_y = my - dy;
 
-                    let (mx_i, my_i) = pixels.window_pos_to_pixel((mx as f64, my as f64));
-                    let (px_i, py_i) = pixels.window_pos_to_pixel((prev_x as f64, prev_y as f64));
+                    let (mx_i, my_i) = pixels
+                        .window_pos_to_pixel((mx as f64, my as f64))
+                        .unwrap_or_else(|(x, y)| {
+                            (
+                                x.max(0).min(SCREEN_WIDTH as isize - 1) as usize,
+                                y.max(0).min(SCREEN_HEIGHT as isize - 1) as usize,
+                            )
+                        });
+
+                    let (px_i, py_i) = pixels
+                        .window_pos_to_pixel((prev_x as f64, prev_y as f64))
+                        .unwrap_or_else(|(x, y)| {
+                            (
+                                x.max(0).min(SCREEN_WIDTH as isize - 1) as usize,
+                                y.max(0).min(SCREEN_HEIGHT as isize - 1) as usize,
+                            )
+                        });
+
                     (
                         (mx_i as isize, my_i as isize),
                         (px_i as isize, py_i as isize),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,32 +320,21 @@ impl Pixels {
         let pos = [
             (physical_position.0 as f32 / physical_size.0 as f32 - 0.5) * pixels_width,
             (physical_position.1 as f32 / physical_size.1 as f32 - 0.5) * pixels_height,
-            0.0,
-            1.0,
         ];
+        // Pos vector: (x, y, 0, 1)
 
         let matrix = self.scaling_matrix_inverse;
+
+        // new_pos: (x, y, w) - z isn't needed so it isn't calculated
         let new_pos = [
-            matrix[0][0] * pos[0]
-                + matrix[0][1] * pos[1]
-                + matrix[0][2] * pos[2]
-                + matrix[0][3] * pos[3],
-            matrix[1][0] * pos[0]
-                + matrix[1][1] * pos[1]
-                + matrix[1][2] * pos[2]
-                + matrix[1][3] * pos[3],
-            matrix[2][0] * pos[0]
-                + matrix[2][1] * pos[1]
-                + matrix[2][2] * pos[2]
-                + matrix[2][3] * pos[3],
-            matrix[3][0] * pos[0]
-                + matrix[3][1] * pos[1]
-                + matrix[3][2] * pos[2]
-                + matrix[3][3] * pos[3],
+            matrix[0][0] * pos[0] + matrix[0][1] * pos[1] + matrix[0][3],
+            matrix[1][0] * pos[0] + matrix[1][1] * pos[1] + matrix[1][3],
+            matrix[3][0] * pos[0] + matrix[3][1] * pos[1] + matrix[3][3],
         ];
+
         let new_pos = (
-            new_pos[0] / new_pos[3] + pixels_width / 2.0,
-            -new_pos[1] / new_pos[3] + pixels_height / 2.0,
+            new_pos[0] / new_pos[2] + pixels_width / 2.0,
+            -new_pos[1] / new_pos[2] + pixels_height / 2.0,
         );
         let pixel_x = new_pos.0.floor() as isize;
         let pixel_y = new_pos.1.floor() as isize;

--- a/src/renderers.rs
+++ b/src/renderers.rs
@@ -196,10 +196,8 @@ impl ScalingMatrix {
     // texture_size is the dimensions of the drawing texture
     // screen_size is the dimensions of the surface being drawn to
     pub(crate) fn new(texture_size: (f32, f32), screen_size: (f32, f32)) -> ScalingMatrix {
-        let screen_width = screen_size.0;
-        let screen_height = screen_size.1;
-        let texture_width = texture_size.0;
-        let texture_height = texture_size.1;
+        let (screen_width, screen_height) = screen_size;
+        let (texture_width, texture_height) = texture_size;
 
         // Get smallest scale size
         let scale = (screen_width / texture_width)

--- a/src/renderers.rs
+++ b/src/renderers.rs
@@ -41,25 +41,17 @@ impl Renderer {
         });
 
         // Create uniform buffer
-        #[rustfmt::skip]
-        let transform: [f32; 16] = [
-            1.0, 0.0, 0.0, 0.0,
-            0.0, -1.0, 0.0, 0.0,
-            0.0, 0.0, 1.0, 0.0,
-            0.0, 0.0, 0.0, 1.0,
-        ];
-        let mut tranform_bytes: Vec<u8> = Vec::with_capacity(4 * transform.len());
-        transform
-            .iter()
-            .map(|e| e.to_bits().to_ne_bytes())
-            .for_each(|b| tranform_bytes.extend(b.iter()));
-        let mapped = device.create_buffer_mapped(&wgpu::BufferDescriptor {
-            label: None,
-            size: tranform_bytes.len() as u64,
-            usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
-        });
-        mapped.data.copy_from_slice(&tranform_bytes);
-        let uniform_buffer = mapped.finish();
+        // TODO: This should also have the width / height of the of the window surface,
+        // so that it won't break when the window is created with a different size.
+        let matrix = ScalingMatrix::new(
+            (texture_size.width as f32, texture_size.height as f32),
+            (texture_size.width as f32, texture_size.height as f32),
+        );
+        let transform_bytes = matrix.as_bytes();
+        let uniform_buffer = device.create_buffer_with_data(
+            &transform_bytes,
+            wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
+        );
 
         // Create bind group
         let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
@@ -176,38 +168,12 @@ impl RenderPass for Renderer {
     }
 
     fn resize(&mut self, encoder: &mut wgpu::CommandEncoder, width: u32, height: u32) {
-        let width = width as f32;
-        let height = height as f32;
+        let matrix = ScalingMatrix::new((self.width, self.height), (width as f32, height as f32));
+        let transform_bytes = matrix.as_bytes();
 
-        // Get smallest scale size
-        let scale = (width / self.width)
-            .min(height / self.height)
-            .max(1.0)
-            .floor();
-
-        // Update transformation matrix
-        let sw = self.width * scale / width;
-        let sh = self.height * scale / height;
-        #[rustfmt::skip]
-        let transform: [f32; 16] = [
-            sw, 0.0, 0.0, 0.0,
-            0.0, -sh, 0.0, 0.0,
-            0.0, 0.0, 1.0, 0.0,
-            0.0, 0.0, 0.0, 1.0,
-        ];
-        let mut tranform_bytes: Vec<u8> = Vec::with_capacity(4 * transform.len());
-        transform
-            .iter()
-            .map(|e| e.to_bits().to_ne_bytes())
-            .for_each(|b| tranform_bytes.extend(b.iter()));
-        let mapped = self.device.create_buffer_mapped(&wgpu::BufferDescriptor {
-            label: None,
-            size: tranform_bytes.len() as u64,
-            usage: wgpu::BufferUsage::COPY_SRC,
-        });
-        mapped.data.copy_from_slice(&tranform_bytes);
-        let temp_buf = mapped.finish();
-        encoder.copy_buffer_to_buffer(&temp_buf, 0, &self.uniform_buffer, 0, 64);
+        let temp_buf = self
+            .device
+            .create_buffer_with_data(&transform_bytes, wgpu::BufferUsage::COPY_SRC);
         encoder.copy_buffer_to_buffer(&temp_buf, 0, &self.uniform_buffer, 0, 64);
     }
 
@@ -217,5 +183,118 @@ impl RenderPass for Renderer {
 
     fn debug(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ScalingMatrix {
+    pub(crate) transform: [[f32; 4]; 4],
+}
+
+impl ScalingMatrix {
+    // texture_size is the dimensions of the drawing texture
+    // screen_size is the dimensions of the surface being drawn to
+    pub(crate) fn new(texture_size: (f32, f32), screen_size: (f32, f32)) -> ScalingMatrix {
+        let screen_width = screen_size.0;
+        let screen_height = screen_size.1;
+        let texture_width = texture_size.0;
+        let texture_height = texture_size.1;
+
+        // Get smallest scale size
+        let scale = (screen_width / texture_width)
+            .min(screen_height / texture_height)
+            .max(1.0)
+            .floor();
+
+        // Update transformation matrix
+        let sw = texture_width * scale / screen_width;
+        let sh = texture_height * scale / screen_height;
+        #[rustfmt::skip]
+        let transform: [[f32; 4]; 4] = [
+            [sw,  0.0, 0.0, 0.0],
+            [0.0, -sh, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ];
+
+        ScalingMatrix { transform }
+    }
+
+    // Could be done with unsafe code or a library like bytemuck, but that
+    // shouldn't be needed as this is rarely called (only on creation / resize).
+    fn as_bytes(&self) -> [u8; 4 * 4 * 4] {
+        let mut transform_bytes = [0; 4 * 4 * 4];
+        let mut i = 0;
+        for row in self.transform.iter() {
+            for f in row.iter() {
+                for b in f.to_bits().to_ne_bytes().iter() {
+                    transform_bytes[i] = *b;
+                    i += 1;
+                }
+            }
+        }
+        transform_bytes
+    }
+
+    // Calculate the inverse of the 4x4 matrix
+    // This is a ported version of https://stackoverflow.com/questions/1148309/inverting-a-4x4-matrix#answer-44446912
+    // This should probably use a library instead, but it isn't worth
+    // adding a large dependency for one function
+    #[rustfmt::skip]
+    pub(crate) fn inverse(&self) -> [[f32; 4]; 4] {
+        let m = &self.transform;
+        let a2323 = m[2][2] * m[3][3] - m[2][3] * m[3][2];
+        let a1323 = m[2][1] * m[3][3] - m[2][3] * m[3][1];
+        let a1223 = m[2][1] * m[3][2] - m[2][2] * m[3][1];
+        let a0323 = m[2][0] * m[3][3] - m[2][3] * m[3][0];
+        let a0223 = m[2][0] * m[3][2] - m[2][2] * m[3][0];
+        let a0123 = m[2][0] * m[3][1] - m[2][1] * m[3][0];
+        let a2313 = m[1][2] * m[3][3] - m[1][3] * m[3][2];
+        let a1313 = m[1][1] * m[3][3] - m[1][3] * m[3][1];
+        let a1213 = m[1][1] * m[3][2] - m[1][2] * m[3][1];
+        let a2312 = m[1][2] * m[2][3] - m[1][3] * m[2][2];
+        let a1312 = m[1][1] * m[2][3] - m[1][3] * m[2][1];
+        let a1212 = m[1][1] * m[2][2] - m[1][2] * m[2][1];
+        let a0313 = m[1][0] * m[3][3] - m[1][3] * m[3][0];
+        let a0213 = m[1][0] * m[3][2] - m[1][2] * m[3][0];
+        let a0312 = m[1][0] * m[2][3] - m[1][3] * m[2][0];
+        let a0212 = m[1][0] * m[2][2] - m[1][2] * m[2][0];
+        let a0113 = m[1][0] * m[3][1] - m[1][1] * m[3][0];
+        let a0112 = m[1][0] * m[2][1] - m[1][1] * m[2][0];
+
+        let mut det =
+              m[0][0] * (m[1][1] * a2323 - m[1][2] * a1323 + m[1][3] * a1223)
+            - m[0][1] * (m[1][0] * a2323 - m[1][2] * a0323 + m[1][3] * a0223)
+            + m[0][2] * (m[1][0] * a1323 - m[1][1] * a0323 + m[1][3] * a0123)
+            - m[0][3] * (m[1][0] * a1223 - m[1][1] * a0223 + m[1][2] * a0123);
+
+        det = 1.0 / det;
+
+        [
+            [
+                det *  (m[1][1] * a2323 - m[1][2] * a1323 + m[1][3] * a1223),
+                det * -(m[0][1] * a2323 - m[0][2] * a1323 + m[0][3] * a1223),
+                det *  (m[0][1] * a2313 - m[0][2] * a1313 + m[0][3] * a1213),
+                det * -(m[0][1] * a2312 - m[0][2] * a1312 + m[0][3] * a1212),
+            ],
+            [
+                det * -(m[1][0] * a2323 - m[1][2] * a0323 + m[1][3] * a0223),
+                det *  (m[0][0] * a2323 - m[0][2] * a0323 + m[0][3] * a0223),
+                det * -(m[0][0] * a2313 - m[0][2] * a0313 + m[0][3] * a0213),
+                det *  (m[0][0] * a2312 - m[0][2] * a0312 + m[0][3] * a0212),
+            ],
+            [
+                det *  (m[1][0] * a1323 - m[1][1] * a0323 + m[1][3] * a0123),
+                det * -(m[0][0] * a1323 - m[0][1] * a0323 + m[0][3] * a0123),
+                det *  (m[0][0] * a1313 - m[0][1] * a0313 + m[0][3] * a0113),
+                det * -(m[0][0] * a1312 - m[0][1] * a0312 + m[0][3] * a0112),
+            ],
+            [
+                det * -(m[1][0] * a1223 - m[1][1] * a0223 + m[1][2] * a0123),
+                det *  (m[0][0] * a1223 - m[0][1] * a0223 + m[0][2] * a0123),
+                det * -(m[0][0] * a1213 - m[0][1] * a0213 + m[0][2] * a0113),
+                det *  (m[0][0] * a1212 - m[0][1] * a0212 + m[0][2] * a0112),
+            ],
+        ]
     }
 }


### PR DESCRIPTION
Adds the method `window_pos_to_pixel` to `Pixels`, which converts physical coordinates into pixel coordinates. (Implements #39) 

* The method name isn't great, but I'm not sure of a better name for it that is still descriptive.
* This currently clamps the output to within the inner window frame (excluding the margins).  Should this return `None` instead if the cursor position is outside of the margins?
* This also doesn't deal with the pixel aspect ratio (which should probably have something in the documentation stating that it isn't implemented yet), so it will have to be updated when that is implemented.
* Should this use `f32` or `f64`, and what integer type should it return?  Winit uses `f64` as the default floating point type for cursor positions, so that is what it currently uses.