### PR TITLE
Switch from futures-executor to pollster

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 [dependencies]
 thiserror = "1.0.15"
 wgpu = "0.5.0"
-futures-executor = "0.3"
+pollster = "0.2"
 ultraviolet = "0.4.6"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -557,7 +557,7 @@ impl<'req> PixelsBuilder<'req> {
     /// Returns an error when a [`wgpu::Adapter`] cannot be found.
     pub fn build(self) -> Result<Pixels, Error> {
         // TODO: Use `options.pixel_aspect_ratio` to stretch the scaled texture
-        let adapter = futures_executor::block_on(wgpu::Adapter::request(
+        let adapter = pollster::block_on(wgpu::Adapter::request(
             &self
                 .request_adapter_options
                 .unwrap_or(wgpu::RequestAdapterOptions {
@@ -568,8 +568,7 @@ impl<'req> PixelsBuilder<'req> {
         ))
         .ok_or(Error::AdapterNotFound)?;
 
-        let (device, queue) =
-            futures_executor::block_on(adapter.request_device(&self.device_descriptor));
+        let (device, queue) = pollster::block_on(adapter.request_device(&self.device_descriptor));
         let device = Rc::new(device);
         let queue = Rc::new(RefCell::new(queue));
 


### PR DESCRIPTION
This is a simpler alternative, eventually when wgpu updates, we probably want to switch to the sync functions versions (see https://github.com/gfx-rs/wgpu-rs/pull/248).