### PR TITLE
Temporary workaround to fix build on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,12 @@ wgpu = "0.5.0"
 pollster = "0.2"
 ultraviolet = "0.4.6"
 
+# Workaround for build error on macOS
+# Remove this when `gfx-backend-metal` is fixed
+# See: https://github.com/gfx-rs/gfx/pull/3311
+[target.'cfg(target_os = "macos")'.dependencies]
+metal = "=0.18.0"
+
 [dev-dependencies]
 pixels-mocks = { path = "pixels-mocks" }
 winit = "0.22.0"


### PR DESCRIPTION
This could be removed when https://github.com/gfx-rs/gfx/pull/3311 is completed and a new release of `gfx-backend-metal` is published.