### PR TITLE
Expose new API method render_texture_format().

### DIFF
--- a/src/renderers.rs
+++ b/src/renderers.rs
@@ -9,6 +9,7 @@ pub struct ScalingRenderer {
     render_pipeline: wgpu::RenderPipeline,
     width: f32,
     height: f32,
+    render_texture_format: wgpu::TextureFormat,
 }
 
 impl ScalingRenderer {
@@ -16,6 +17,7 @@ impl ScalingRenderer {
         device: &wgpu::Device,
         texture_view: &wgpu::TextureView,
         texture_size: &wgpu::Extent3d,
+        render_texture_format: wgpu::TextureFormat,
     ) -> Self {
         let vs_module = device.create_shader_module(wgpu::include_spirv!("../shaders/vert.spv"));
         let fs_module = device.create_shader_module(wgpu::include_spirv!("../shaders/frag.spv"));
@@ -126,7 +128,7 @@ impl ScalingRenderer {
             }),
             primitive_topology: wgpu::PrimitiveTopology::TriangleList,
             color_states: &[wgpu::ColorStateDescriptor {
-                format: wgpu::TextureFormat::Bgra8UnormSrgb,
+                format: render_texture_format,
                 color_blend: wgpu::BlendDescriptor::REPLACE,
                 alpha_blend: wgpu::BlendDescriptor::REPLACE,
                 write_mask: wgpu::ColorWrite::ALL,
@@ -147,6 +149,7 @@ impl ScalingRenderer {
             render_pipeline,
             width: texture_size.width as f32,
             height: texture_size.height as f32,
+            render_texture_format,
         }
     }
 


### PR DESCRIPTION
This method is needed to let the user of the API configure the texture format of the target texture/render texture that the surface texture is rendered on. This texture format is hardware/platform dependent.

For example, this method makes it possible to use the pixels crate on Android because Android seems to not use the texture format `wgpu::TextureFormat::Bgra8UnormSrgb` that is currently hard-coded in `pixels`. Trying to use the current version of `pixels` on Android results in an `adb logcat` entry similar to:

```
requested format Bgra8Srgb is not in list of supported formats:
   [Rgba8Unorm, Rgba8Srgb, R5g6b5Unorm, A2b10g10r10Unorm, Rgba16Sfloat]
```

Using the new method `render_texture_format(TextureFormat::Rgba8UnormSrgb)`, the application starts and displays the pixel buffer as expected. The chosen `TextureFormat` might be hardware dependent but was tested successfully on a Samsung Galaxy S10+ and a Google Pixel 3a.

The name "`render_texture_format`" is open for discussion, as I am not versed enough in graphics programming to determine whether this is the right nomenclature.

A working example (though a bit complicated to set up) using `ndk-glue`, `winit` and my fork of pixels (that implements the new `render_texture_format()` method) can be found at http://github.com/schnippl0r/pixelfire-android