### PR TITLE
Update invaders example with Wayland support

### DIFF
--- a/examples/invaders/Cargo.toml
+++ b/examples/invaders/Cargo.toml
@@ -18,5 +18,5 @@ log = "0.4.8"
 pixels = { path = "../.." }
 randomize = "3.0.1"
 simple-invaders = { path = "simple-invaders" }
-winit = "0.22.0"
-winit_input_helper = "0.6.0"
+winit = "0.23.0"
+winit_input_helper = "0.8.0"

--- a/examples/invaders/src/main.rs
+++ b/examples/invaders/src/main.rs
@@ -143,20 +143,11 @@ fn create_window(
     let height = SCREEN_HEIGHT as f64;
     let (monitor_width, monitor_height) = {
         let (width, height) = if let Some(monitor) = window.current_monitor() {
-            (
-                monitor.size().width,
-                monitor.size().height,
-            )
+            (monitor.size().width, monitor.size().height)
         } else {
-            (
-                640,
-                480,
-            )
+            (640, 480)
         };
-        (
-            width as f64 / hidpi_factor,
-            height as f64 / hidpi_factor,
-        )
+        (width as f64 / hidpi_factor, height as f64 / hidpi_factor)
     };
     let scale = (monitor_height / height * 2.0 / 3.0).round();
 

--- a/examples/invaders/src/main.rs
+++ b/examples/invaders/src/main.rs
@@ -60,7 +60,7 @@ fn main() -> Result<(), Error> {
 
         // For everything else, for let winit_input_helper collect events to build its state.
         // It returns `true` when it is time to update our game state and request a redraw.
-        if input.update(event) {
+        if input.update(&event) {
             // Close events
             if input.key_pressed(VirtualKeyCode::Escape) || input.quit() {
                 *control_flow = ControlFlow::Exit;
@@ -142,10 +142,20 @@ fn create_window(
     let width = SCREEN_WIDTH as f64;
     let height = SCREEN_HEIGHT as f64;
     let (monitor_width, monitor_height) = {
-        let size = window.current_monitor().size();
+        let (width, height) = if let Some(monitor) = window.current_monitor() {
+            (
+                monitor.size().width,
+                monitor.size().height,
+            )
+        } else {
+            (
+                640,
+                480,
+            )
+        };
         (
-            size.width as f64 / hidpi_factor,
-            size.height as f64 / hidpi_factor,
+            width as f64 / hidpi_factor,
+            height as f64 / hidpi_factor,
         )
     };
     let scale = (monitor_height / height * 2.0 / 3.0).round();


### PR DESCRIPTION
These are the changes I had to make to get this to compile and run on Wayland.

After updating the crates I got a couple errors:
```
error[E0308]: mismatched types
  --> examples/invaders/src/main.rs:63:25
   |
63 |         if input.update(event) {
   |                         ^^^^^
   |                         |
   |                         expected reference, found enum `winit::event::Event`
   |                         help: consider borrowing here: `&event`
   |
   = note: expected reference `&winit::event::Event<'_, _>`
                   found enum `winit::event::Event<'_, ()>`

error[E0599]: no method named `size` found for enum `Option<winit::monitor::MonitorHandle>` in the current scope
   --> examples/invaders/src/main.rs:145:45
    |
145 |         let size = window.current_monitor().size();
    |                                             ^^^^ method not found in `Option<winit::monitor::MonitorHandle>`                                    
```