### PR TITLE
Resize buffer (issue #125)

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -251,19 +251,35 @@ impl<'req, 'win, W: HasRawWindowHandle> PixelsBuilder<'req, 'win, W> {
             swap_chain,
             texture,
             texture_extent,
+            texture_format: self.texture_format,
             texture_format_size,
             scaling_renderer,
         };
-
-        Ok(Pixels {
+        let mut pixels = Pixels {
             context,
             surface_size,
             present_mode,
             pixels,
             scaling_matrix_inverse,
             render_texture_format: self.render_texture_format,
-        })
+        };
+        create_swap_chain(&mut pixels);
+
+        Ok(pixels)
     }
+}
+
+pub(crate) fn create_swap_chain(pixels: &mut Pixels) {
+    pixels.context.swap_chain = pixels.context.device.create_swap_chain(
+        &pixels.context.surface,
+        &wgpu::SwapChainDescriptor {
+            usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+            format: pixels.render_texture_format,
+            width: pixels.surface_size.width,
+            height: pixels.surface_size.height,
+            present_mode: pixels.present_mode,
+        },
+    );
 }
 
 fn get_texture_format_size(texture_format: wgpu::TextureFormat) -> f32 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,11 +193,11 @@ impl Pixels {
 
         // Update ScalingMatrix for mouse transformation
         self.scaling_matrix_inverse = renderers::ScalingMatrix::new(
-            (
-                self.context.texture_extent.width as f32,
-                self.context.texture_extent.height as f32,
-            ),
             (width as f32, height as f32),
+            (
+                self.surface_size.width as f32,
+                self.surface_size.height as f32,
+            ),
         )
         .transform
         .inversed();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,7 +256,7 @@ impl Pixels {
         .inversed();
 
         // Recreate the swap chain
-        builder::create_swap_chain(self);
+        self.re_create_swap_chain();
 
         // Update state for all render passes
         self.context
@@ -345,7 +345,7 @@ impl Pixels {
                 wgpu::SwapChainError::Outdated => {
                     // Recreate the swap chain to mitigate race condition on drawing surface resize.
                     // See https://github.com/parasyte/pixels/issues/121
-                    builder::create_swap_chain(self);
+                    self.re_create_swap_chain();
                     self.context.swap_chain.get_current_frame()
                 }
                 err => Err(err),
@@ -381,6 +381,18 @@ impl Pixels {
 
         self.context.queue.submit(Some(encoder.finish()));
         Ok(())
+    }
+
+    // Re-create the swap chain with its own values
+    pub(crate) fn re_create_swap_chain(&mut self) {
+        self.context.swap_chain = builder::create_swap_chain(
+            &mut self.context.device,
+            &self.context.surface,
+            self.render_texture_format,
+            self.surface_size.width,
+            self.surface_size.height,
+            self.present_mode,
+        );
     }
 
     /// Get a mutable byte slice for the pixel buffer. The buffer is _not_ cleared for you; it will


### PR DESCRIPTION
Function to resize the pixel buffer:

pub fn resize_buffer(&mut self, width: u32, height: u32)

The backing texture and swap chain are re-created and the buffer is resized.
The texture format also has to be stored at creation of `Pixels` so that the texture can be re-created with the same format.

I also updated example `imgui-winit` to account for the resized width when `world::draw()`-ing.

This ~~addresses~~ may help with #125.