### PR TITLE
Fix build for imgui-winit example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.43.0
+          - 1.46.0
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -40,7 +40,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.43.0
+          - 1.46.0
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/examples/imgui-winit/Cargo.toml
+++ b/examples/imgui-winit/Cargo.toml
@@ -11,9 +11,9 @@ default = ["optimize"]
 
 [dependencies]
 env_logger = "0.8"
-imgui = "0.6"
-imgui-wgpu = "0.12"
-imgui-winit-support = "0.6"
+imgui = "0.7"
+imgui-wgpu = { git = "https://github.com/parasyte/imgui-wgpu-rs.git", rev = "8da89b3ad1ef54384b7ff4bd550adf9f808df1f8" }
+imgui-winit-support = "0.7"
 log = "0.4"
 pixels = { path = "../.." }
 winit = "0.24"


### PR DESCRIPTION
- The dependencies are a mess!
- Had to fork `imgui-wgpu`, which sits between 0.12 and 0.13 (has support for `winit` 0.24, but not `wgpu` 0.7)
- This is a temporary fix for CI, until https://github.com/Yatekii/imgui-wgpu-rs/pull/44 is merged and a new release of `imgui-wgpu` is out
- The WIP `wgpu` 0.7 update in https://github.com/parasyte/pixels/pull/134 will be needed for `imgui-wgpu` 0.14