### PR TITLE
Fix matrix when creating a scaling renderer

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -309,6 +309,7 @@ pub(crate) fn create_backing_texture(
         device,
         &texture_view,
         &texture_extent,
+        surface_size,
         render_texture_format,
     );
 

--- a/src/renderers.rs
+++ b/src/renderers.rs
@@ -1,3 +1,4 @@
+use crate::SurfaceSize;
 use ultraviolet::Mat4;
 use wgpu::util::DeviceExt;
 
@@ -17,6 +18,7 @@ impl ScalingRenderer {
         device: &wgpu::Device,
         texture_view: &wgpu::TextureView,
         texture_size: &wgpu::Extent3d,
+        surface_size: &SurfaceSize,
         render_texture_format: wgpu::TextureFormat,
     ) -> Self {
         let vs_module = device.create_shader_module(&wgpu::include_spirv!("../shaders/vert.spv"));
@@ -39,11 +41,9 @@ impl ScalingRenderer {
         });
 
         // Create uniform buffer
-        // TODO: This should also have the width / height of the of the window surface,
-        // so that it won't break when the window is created with a different size.
         let matrix = ScalingMatrix::new(
             (texture_size.width as f32, texture_size.height as f32),
-            (texture_size.width as f32, texture_size.height as f32),
+            (surface_size.width as f32, surface_size.height as f32),
         );
         let transform_bytes = matrix.as_bytes();
         let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {


### PR DESCRIPTION
- This issue can be seen when creating a window and pixel buffer that have differing sizes; the image will be stretched to fill the window.
- If the window supports the resize callback to correct the image aspect ratio, resizing the window will correct the matrix immediately, adding the black border as expected. This is a jarring effect when the texture size ratio is not an integer.
- This bug also causes issues with the new `resize_buffer()` API.

This fixes a long-standing issue with the scaling renderer. It was made more obvious with the new `resize_buffer()` API, and reported in https://github.com/parasyte/pixels/pull/136#issuecomment-787532492

r? @JMS55 