### PR TITLE
Add MSRV policy

### DIFF
--- a/MSRV.md
+++ b/MSRV.md
@@ -12,6 +12,6 @@
 
 ## Policy
 
-The table above will be kept to up-to-date in lock-step with CI on the main branch in GitHub. It may contain information about unreleased and yanked versions.
+The table above will be kept to up-to-date in lock-step with CI on the main branch in GitHub. It may contain information about unreleased and yanked versions. It is the user's responsibility to consult with the [`pixels` versions page](https://crates.io/crates/pixels/versions) on `crates.io` to verify version status.
 
-It is the user's responsibility to consult with the [versions page](https://crates.io/crates/pixels/versions) on `crates.io` to verify version status.
+The MSRV will be chosen as the minimum version of `rustc` that can successfully pass CI, including documentation, lints, and all examples. For this reason, the minimum version _supported_ may be higher than the minimum version _required_ to compile the `pixels` crate itself.

--- a/MSRV.md
+++ b/MSRV.md
@@ -1,0 +1,17 @@
+# Minimum Supported Rust Version
+
+| `pixels` version | `rustc` version |
+|------------------|-----------------|
+| `0.3.0`          | `1.50.0`        |
+| `0.2.0`          | `1.41.0`        |
+| `0.1.0`          | `1.41.0`        |
+| `0.0.4`          | `1.40.0`        |
+| `0.0.3`          | `1.40.0`        |
+| `0.0.2`          | `1.36.0`        |
+| `0.0.1`          | `1.36.0`        |
+
+## Policy
+
+The table above will be kept to up-to-date in lock-step with CI on the main branch in GitHub. It may contain information about unreleased and yanked versions.
+
+It is the user's responsibility to consult with the [versions page](https://crates.io/crates/pixels/versions) on `crates.io` to verify version status.

--- a/README.md
+++ b/README.md
@@ -13,10 +13,14 @@ Rapidly prototype a simple 2D game, pixel-based animations, software renderers, 
 
 `pixels` is more than just a library to push pixels to a screen, but less than a full framework. You're in charge of managing a window environment, event loop, and input handling.
 
+## MSRV Policy
+
+The Minimum Supported Rust Version for `pixels` will always be made available in the [MSRV.md](./MSRV.md) file on GitHub.
+
 ## Features
 
 - Built on modern graphics APIs powered by [`wgpu`](https://crates.io/crates/wgpu): DirectX 12, Vulkan, Metal. OpenGL support is a work in progress.
-- Use your own custom shaders for special effects. (WIP)
+- Use your own custom shaders for special effects.
 - Hardware accelerated scaling on perfect pixel boundaries.
 - Supports non-square pixel aspect ratios. (WIP)
 


### PR DESCRIPTION
Also updates the README to remove the "WIP" label from the custom shader feature. It is pretty much stable enough. And I don't feel the necessity to create a policy for features right now.