### PR TITLE
Update fltk

### DIFF
--- a/examples/minimal-fltk/Cargo.toml
+++ b/examples/minimal-fltk/Cargo.toml
@@ -10,7 +10,7 @@ optimize = ["log/release_max_level_warn"]
 default = ["optimize"]
 
 [dependencies]
-fltk = { version = "1.0", features = ["no-images", "no-pango"] }
+fltk = { version = "1.0.14", features = ["no-images", "no-pango"] }
 env_logger = "0.8"
 log = "0.4"
 pixels = { path = "../.." }


### PR DESCRIPTION
- Fixes #163
- Reimplements window resize
  - Still has problems on macOS; Resizing with the drag handle blocks the main loop. See:
    - https://github.com/glfw/glfw/issues/1251
    - https://github.com/rust-windowing/winit/issues/219