### PR TITLE
Add user-defined errors for render functions

### DIFF
--- a/examples/custom-shader/src/main.rs
+++ b/examples/custom-shader/src/main.rs
@@ -60,6 +60,8 @@ fn main() -> Result<(), Error> {
                 time += 0.01;
 
                 noise_renderer.render(encoder, render_target, context.scaling_renderer.clip_rect());
+
+                Ok(())
             });
 
             if render_result

--- a/examples/egui-winit/src/main.rs
+++ b/examples/egui-winit/src/main.rs
@@ -67,8 +67,9 @@ fn main() -> Result<(), Error> {
                 context.scaling_renderer.render(encoder, render_target);
 
                 // Render egui
-                gui.render(encoder, render_target, context)
-                    .expect("egui render error");
+                gui.render(encoder, render_target, context)?;
+
+                Ok(())
             });
 
             // Basic error handling

--- a/examples/imgui-winit/src/main.rs
+++ b/examples/imgui-winit/src/main.rs
@@ -70,8 +70,9 @@ fn main() -> Result<(), Error> {
                 context.scaling_renderer.render(encoder, render_target);
 
                 // Render Dear ImGui
-                gui.render(&window, encoder, render_target, context)
-                    .expect("gui.render() failed");
+                gui.render(&window, encoder, render_target, context)?;
+
+                Ok(())
             });
 
             // Basic error handling

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,6 +342,7 @@ impl Pixels {
     /// pixels.render_with(|encoder, render_target, context| {
     ///     context.scaling_renderer.render(encoder, render_target);
     ///     // etc...
+    ///     Ok(())
     /// });
     /// # Ok::<(), pixels::Error>(())
     /// ```


### PR DESCRIPTION
- Fixes #189

This was so much easier than I thought it would be. Last time I tried this, it was a huge pain. This change was absolutely effortless! Worked first time. Even though there isn't much to it, and most upgrades will need to add a seemly useless `Ok(())`, this really is a game-changer for error handling inside custom render functions.

The error is simply bubbled to the outer caller, and the game loop can decide how it wants to handle these errors.