### PR TITLE
Added `get_frame_u32` function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pixels"
 description = "A tiny library providing a GPU-powered pixel frame buffer."
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Jay Oster <jay@kodewerx.org>"]
 edition = "2018"
 repository = "https://github.com/parasyte/pixels"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -444,10 +444,6 @@ impl Pixels {
     ///
     /// This function will fail if the internal pixels array is not 4-byte
     /// aligned, which should always be the case.
-    ///
-    /// The pixel channels order is 0xAABBGGRRu32.  For example, 0x12345678u32
-    /// will produce an alpha of 0x12, a blue of 0x34, a green of 0x56 and a red
-    /// of 0x78.
     pub fn get_frame_u32(&mut self) -> &mut [u32] {
         let result = bytemuck::try_cast_slice_mut::<u8, u32>(&mut self.pixels);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,6 +438,26 @@ impl Pixels {
         &mut self.pixels
     }
 
+    /// Get a mutable u32 slice for the pixel buffer.  The buffer is _not_
+    /// cleared for you; it will retain the previous frame's contents until you
+    /// clear it yourself.
+    ///
+    /// This function will fail if the internal pixels array is not 4-byte
+    /// aligned, which should always be the case.
+    ///
+    /// The pixel channels order is 0xAABBGGRRu32.  For example, 0x12345678u32
+    /// will produce an alpha of 0x12, a blue of 0x34, a green of 0x56 and a red
+    /// of 0x78.
+    pub fn get_frame_u32(&mut self) -> &mut [u32] {
+        let result = bytemuck::try_cast_slice_mut::<u8, u32>(&mut self.pixels);
+
+        if let Ok(slice) = result {
+            slice
+        } else {
+            panic!("Pixels are not aligned on 4-byte boundaries");
+        }
+    }
+
     /// Calculate the pixel location from a physical location on the window,
     /// dealing with window resizing, scaling, and margins. Takes a physical
     /// position (x, y) within the window, and returns a pixel position (x, y).


### PR DESCRIPTION
When dealing with pixels, I often prefer to use u32s rather than a series of 4 u8s.  This allows for faster code dealing with blotting sprites or generating images etc.  I've added a `get_frame_u32` to allow access to a slice of u32s instead of u8s.  I used the `bytemuck` crate for the casting from `self.pixels` as you already use it.  Furthermore, I use the `try` version of the casting and if the u8 slice is not aligned on a boundary of 4 bytes or is not a multiple of 4 bytes in length, a panic will occur.  This should never be the case.

I've also bumped the minor version as this is an API change.