### PR TITLE
Remove patch number from dependency versions

### DIFF
--- a/examples/minimal-fltk/Cargo.toml
+++ b/examples/minimal-fltk/Cargo.toml
@@ -11,7 +11,7 @@ optimize = ["log/release_max_level_warn"]
 default = ["optimize"]
 
 [dependencies]
-fltk = { version = "1.2.6", features = ["raw-window-handle", "no-images", "no-pango"] }
+fltk = { version = "1.2", features = ["raw-window-handle", "no-images", "no-pango"] }
 env_logger = "0.9"
 log = "0.4"
 pixels = { path = "../.." }


### PR DESCRIPTION
- Cargo treats non-prefixed version numbers the same when the patch number is omitted.
- This is just cleaner and makes breaking updates easier to manage.