### PR TITLE
Fix `minimal-fltk` example release builds with Rust 1.56.0

### DIFF
--- a/examples/minimal-fltk/src/main.rs
+++ b/examples/minimal-fltk/src/main.rs
@@ -19,7 +19,9 @@ struct World {
 }
 
 fn main() -> Result<(), Error> {
+    #[cfg(debug_assertions)]
     env_logger::init();
+
     let app = app::App::default();
     let mut win = Window::default()
         .with_size(WIDTH as i32, HEIGHT as i32)


### PR DESCRIPTION
- See https://github.com/rust-lang/rust/issues/88576