### PR TITLE
Implement resize functionality for minimal-web example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,10 +98,6 @@ jobs:
     needs: [checks, lints]
     strategy:
       matrix:
-        rust:
-          - stable
-          - beta
-          - 1.52.0
         example:
           - minimal-web
     steps:
@@ -115,7 +111,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
           target: wasm32-unknown-unknown
           override: true
       - name: Install tools

--- a/examples/minimal-web/Cargo.toml
+++ b/examples/minimal-web/Cargo.toml
@@ -21,6 +21,7 @@ winit = "0.25"
 winit_input_helper = "0.10"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2.78"
 wasm-bindgen-futures = "0.4"
 web-sys = "0.3"
 

--- a/examples/minimal-web/src/main.rs
+++ b/examples/minimal-web/src/main.rs
@@ -3,6 +3,7 @@
 
 use log::error;
 use pixels::{PixelsBuilder, SurfaceTexture};
+use std::rc::Rc;
 use winit::dpi::LogicalSize;
 use winit::event::{Event, VirtualKeyCode};
 use winit::event_loop::{ControlFlow, EventLoop};
@@ -50,10 +51,30 @@ async fn run() {
             .expect("WindowBuilder error")
     };
 
+    let window = Rc::new(window);
+
     #[cfg(target_arch = "wasm32")]
     {
+        use wasm_bindgen::JsCast;
         use winit::platform::web::WindowExtWebSys;
 
+        // Retrieve current width and height dimensions of browser client window
+        let get_window_size = || {
+            let client_window = web_sys::window().unwrap();
+            LogicalSize::new(
+                client_window.inner_width().unwrap().as_f64().unwrap(),
+                client_window.inner_height().unwrap().as_f64().unwrap()
+            )
+        };
+
+        let window = Rc::clone(&window);
+
+        // Initialize winit window with current dimensions of browser client
+        window.set_inner_size(get_window_size());
+
+        let client_window = web_sys::window().unwrap();
+
+        // Attach winit canvas to body element 
         web_sys::window()
             .and_then(|win| win.document())
             .and_then(|doc| doc.body())
@@ -62,12 +83,23 @@ async fn run() {
                     .ok()
             })
             .expect("couldn't append canvas to document body");
+        
+        // Listen for resize event on browser client. Adjust winit window dimensions
+        // on event trigger
+        let closure = wasm_bindgen::closure::Closure::wrap(Box::new(move |_e: web_sys::Event| {
+            let size = get_window_size();
+            window.set_inner_size(size)
+        }) as Box<dyn FnMut(_)>);
+        client_window
+            .add_event_listener_with_callback("resize", closure.as_ref().unchecked_ref())
+            .unwrap();
+        closure.forget();
     }
 
     let mut input = WinitInputHelper::new();
     let mut pixels = {
         let window_size = window.inner_size();
-        let surface_texture = SurfaceTexture::new(window_size.width, window_size.height, &window);
+        let surface_texture = SurfaceTexture::new(window_size.width, window_size.height, window.as_ref());
         PixelsBuilder::new(WIDTH, HEIGHT, surface_texture)
             .wgpu_backend(pixels::wgpu::Backends::all())
             .device_descriptor(pixels::wgpu::DeviceDescriptor {

--- a/examples/minimal-web/src/main.rs
+++ b/examples/minimal-web/src/main.rs
@@ -63,7 +63,7 @@ async fn run() {
             let client_window = web_sys::window().unwrap();
             LogicalSize::new(
                 client_window.inner_width().unwrap().as_f64().unwrap(),
-                client_window.inner_height().unwrap().as_f64().unwrap()
+                client_window.inner_height().unwrap().as_f64().unwrap(),
             )
         };
 
@@ -74,7 +74,7 @@ async fn run() {
 
         let client_window = web_sys::window().unwrap();
 
-        // Attach winit canvas to body element 
+        // Attach winit canvas to body element
         web_sys::window()
             .and_then(|win| win.document())
             .and_then(|doc| doc.body())
@@ -83,7 +83,7 @@ async fn run() {
                     .ok()
             })
             .expect("couldn't append canvas to document body");
-        
+
         // Listen for resize event on browser client. Adjust winit window dimensions
         // on event trigger
         let closure = wasm_bindgen::closure::Closure::wrap(Box::new(move |_e: web_sys::Event| {
@@ -99,7 +99,8 @@ async fn run() {
     let mut input = WinitInputHelper::new();
     let mut pixels = {
         let window_size = window.inner_size();
-        let surface_texture = SurfaceTexture::new(window_size.width, window_size.height, window.as_ref());
+        let surface_texture =
+            SurfaceTexture::new(window_size.width, window_size.height, window.as_ref());
         PixelsBuilder::new(WIDTH, HEIGHT, surface_texture)
             .wgpu_backend(pixels::wgpu::Backends::all())
             .device_descriptor(pixels::wgpu::DeviceDescriptor {


### PR DESCRIPTION
Took a little longer than I expected. I realized I accidently broke the native compilation option.

I saw the discussion about moving the boilerplate stuff into a different crate as a feature or something. Would that be difficult to do? I'd love to take a stab at automizing the wasm stuff, but don't have a lot of confidence in my coding skill. Might need some lite mentorship, but I'd love to tackle it as a learning exercise.   