### PR TITLE
Make SurfaceSize private

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub struct SurfaceTexture<'win, W: HasRawWindowHandle> {
 
 /// A logical texture size for a window surface.
 #[derive(Debug)]
-pub struct SurfaceSize {
+struct SurfaceSize {
     width: u32,
     height: u32,
 }


### PR DESCRIPTION
- This struct is only used internally. No need to make it public.
- Technically a breaking change, so this will bump the SemVer.