### PR TITLE
Experimental support for integration with existing `wgpu` apps.

### DIFF
--- a/examples/custom-shader/src/main.rs
+++ b/examples/custom-shader/src/main.rs
@@ -56,7 +56,7 @@ fn main() -> Result<(), Error> {
                 let noise_texture = noise_renderer.get_texture_view();
                 context.scaling_renderer.render(encoder, noise_texture);
 
-                noise_renderer.update(&context.queue, time);
+                noise_renderer.update(context.queue, time);
                 time += 0.01;
 
                 noise_renderer.render(encoder, render_target, context.scaling_renderer.clip_rect());

--- a/examples/imgui-winit/src/gui.rs
+++ b/examples/imgui-winit/src/gui.rs
@@ -120,7 +120,7 @@ impl Gui {
         });
 
         self.renderer
-            .render(ui.render(), &context.queue, &context.device, &mut rpass)
+            .render(ui.render(), context.queue, context.device, &mut rpass)
     }
 
     /// Handle any outstanding events.

--- a/examples/imgui-winit/src/main.rs
+++ b/examples/imgui-winit/src/main.rs
@@ -70,7 +70,7 @@ fn main() -> Result<(), Error> {
                 context.scaling_renderer.render(encoder, render_target);
 
                 // Render Dear ImGui
-                gui.render(&window, encoder, render_target, context)?;
+                gui.render(&window, encoder, render_target, &context)?;
 
                 Ok(())
             });

--- a/examples/invaders/simple-invaders/src/controls.rs
+++ b/examples/invaders/simple-invaders/src/controls.rs
@@ -1,5 +1,5 @@
 /// Player control inputs.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Controls {
     /// Move the player.
     pub direction: Direction,
@@ -16,15 +16,6 @@ pub enum Direction {
     Left,
     /// Move to the right.
     Right,
-}
-
-impl Default for Controls {
-    fn default() -> Controls {
-        Controls {
-            direction: Direction::default(),
-            fire: false,
-        }
-    }
 }
 
 impl Default for Direction {

--- a/examples/minimal-egui/src/gui.rs
+++ b/examples/minimal-egui/src/gui.rs
@@ -88,12 +88,12 @@ impl Framework {
     ) -> Result<(), BackendError> {
         // Upload all resources to the GPU.
         self.rpass
-            .update_texture(&context.device, &context.queue, &self.egui_ctx.texture());
+            .update_texture(context.device, context.queue, &self.egui_ctx.texture());
         self.rpass
-            .update_user_textures(&context.device, &context.queue);
+            .update_user_textures(context.device, context.queue);
         self.rpass.update_buffers(
-            &context.device,
-            &context.queue,
+            context.device,
+            context.queue,
             &self.paint_jobs,
             &self.screen_descriptor,
         );

--- a/examples/minimal-egui/src/main.rs
+++ b/examples/minimal-egui/src/main.rs
@@ -94,7 +94,7 @@ fn main() -> Result<(), Error> {
                     context.scaling_renderer.render(encoder, render_target);
 
                     // Render egui
-                    framework.render(encoder, render_target, context)?;
+                    framework.render(encoder, render_target, &context)?;
 
                     Ok(())
                 });


### PR DESCRIPTION
- Closes #107

This has a few unavoidable breaking changes. The first is that the closure provided by `Pixels::render_with()` no longer accepts a reference to `PixelsContext`, but an owned copy of one. `PixelsContext` is now a view of the poorly named `PixelsInternalContext` (which is what now owns or borrows the top-level `wgpu` state).

The second breaking change is related to the first: `Pixels::context()` now returns an owned `PixelsContext`. This was ultimately the reason that the closure signature had to change, since this method cannot return a reference to a `PixelsContext` view borrowed from the stack. The closure signature was changed for consistency.

There are now three ways to build a `Pixels` instance:

- `Pixels::new()` remains unchanged. Simply calls `PixelsBuilder::build()`.
- `PixelsBuilder::build()` remains unchanged. Creates a `Pixels` instance that owns the top-level `wgpu` state.
- `PixelsBuilder::build_with_wgpu()` is new, and allows `Pixels` to borrow existing top-level `wgpu` state. See #107 for details.

This PR needs an example before it's ready to merge.