### PR TITLE
Refactor public API

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -40,15 +40,11 @@ impl<'req, 'dev, 'win, W: HasRawWindowHandle> PixelsBuilder<'req, 'dev, 'win, W>
     /// # Panics
     ///
     /// Panics when `width` or `height` are 0.
-    pub fn new(
-        width: u32,
-        height: u32,
-        surface_texture: SurfaceTexture<'win, W>,
-    ) -> PixelsBuilder<'req, 'dev, 'win, W> {
+    pub fn new(width: u32, height: u32, surface_texture: SurfaceTexture<'win, W>) -> Self {
         assert!(width > 0);
         assert!(height > 0);
 
-        PixelsBuilder {
+        Self {
             request_adapter_options: None,
             device_descriptor: wgpu::DeviceDescriptor::default(),
             backend: wgpu::util::backend_bits_from_env().unwrap_or(wgpu::Backends::PRIMARY),
@@ -66,16 +62,13 @@ impl<'req, 'dev, 'win, W: HasRawWindowHandle> PixelsBuilder<'req, 'dev, 'win, W>
     pub fn request_adapter_options(
         mut self,
         request_adapter_options: wgpu::RequestAdapterOptions<'req>,
-    ) -> PixelsBuilder<'req, 'dev, 'win, W> {
+    ) -> Self {
         self.request_adapter_options = Some(request_adapter_options);
         self
     }
 
     /// Add options for requesting a [`wgpu::Device`].
-    pub fn device_descriptor(
-        mut self,
-        device_descriptor: wgpu::DeviceDescriptor<'dev>,
-    ) -> PixelsBuilder<'req, 'dev, 'win, W> {
+    pub fn device_descriptor(mut self, device_descriptor: wgpu::DeviceDescriptor<'dev>) -> Self {
         self.device_descriptor = device_descriptor;
         self
     }
@@ -83,7 +76,7 @@ impl<'req, 'dev, 'win, W: HasRawWindowHandle> PixelsBuilder<'req, 'dev, 'win, W>
     /// Set which backends wgpu will attempt to use.
     ///
     /// The default value is `PRIMARY`, which enables the well supported backends for wgpu.
-    pub fn wgpu_backend(mut self, backend: wgpu::Backends) -> PixelsBuilder<'req, 'dev, 'win, W> {
+    pub fn wgpu_backend(mut self, backend: wgpu::Backends) -> Self {
         self.backend = backend;
         self
     }
@@ -103,10 +96,7 @@ impl<'req, 'dev, 'win, W: HasRawWindowHandle> PixelsBuilder<'req, 'dev, 'win, W>
     ///
     /// This documentation is hidden because support for pixel aspect ratio is incomplete.
     #[doc(hidden)]
-    pub fn pixel_aspect_ratio(
-        mut self,
-        pixel_aspect_ratio: f64,
-    ) -> PixelsBuilder<'req, 'dev, 'win, W> {
+    pub fn pixel_aspect_ratio(mut self, pixel_aspect_ratio: f64) -> Self {
         assert!(pixel_aspect_ratio > 0.0);
 
         self._pixel_aspect_ratio = pixel_aspect_ratio;
@@ -120,7 +110,7 @@ impl<'req, 'dev, 'win, W: HasRawWindowHandle> PixelsBuilder<'req, 'dev, 'win, W>
     /// The `wgpu` present mode will be set to `Fifo` when Vsync is enabled, or `Immediate` when
     /// Vsync is disabled. To set the present mode to `Mailbox` or another value, use the
     /// [`PixelsBuilder::present_mode`] method.
-    pub fn enable_vsync(mut self, enable_vsync: bool) -> PixelsBuilder<'req, 'dev, 'win, W> {
+    pub fn enable_vsync(mut self, enable_vsync: bool) -> Self {
         self.present_mode = if enable_vsync {
             wgpu::PresentMode::Fifo
         } else {
@@ -133,10 +123,7 @@ impl<'req, 'dev, 'win, W: HasRawWindowHandle> PixelsBuilder<'req, 'dev, 'win, W>
     ///
     /// This differs from [`PixelsBuilder::enable_vsync`] by allowing the present mode to be set to
     /// any value.
-    pub fn present_mode(
-        mut self,
-        present_mode: wgpu::PresentMode,
-    ) -> PixelsBuilder<'req, 'dev, 'win, W> {
+    pub fn present_mode(mut self, present_mode: wgpu::PresentMode) -> Self {
         self.present_mode = present_mode;
         self
     }
@@ -149,10 +136,7 @@ impl<'req, 'dev, 'win, W: HasRawWindowHandle> PixelsBuilder<'req, 'dev, 'win, W>
     ///
     /// This is the pixel format of the texture that most applications will interact with directly.
     /// The format influences the structure of byte data that is returned by [`Pixels::get_frame`].
-    pub fn texture_format(
-        mut self,
-        texture_format: wgpu::TextureFormat,
-    ) -> PixelsBuilder<'req, 'dev, 'win, W> {
+    pub fn texture_format(mut self, texture_format: wgpu::TextureFormat) -> Self {
         self.texture_format = texture_format;
         self
     }
@@ -175,10 +159,7 @@ impl<'req, 'dev, 'win, W: HasRawWindowHandle> PixelsBuilder<'req, 'dev, 'win, W>
     /// mind when writing custom shaders for post-processing effects. There is a full example of a
     /// [custom-shader](https://github.com/parasyte/pixels/tree/master/examples/custom-shader)
     /// available that demonstrates how to deal with this.
-    pub fn render_texture_format(
-        mut self,
-        texture_format: wgpu::TextureFormat,
-    ) -> PixelsBuilder<'req, 'dev, 'win, W> {
+    pub fn render_texture_format(mut self, texture_format: wgpu::TextureFormat) -> Self {
         self.render_texture_format = Some(texture_format);
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,13 +152,13 @@ impl<'win, W: HasRawWindowHandle> SurfaceTexture<'win, W> {
     /// # Panics
     ///
     /// Panics when `width` or `height` are 0.
-    pub fn new(width: u32, height: u32, window: &'win W) -> SurfaceTexture<'win, W> {
+    pub fn new(width: u32, height: u32, window: &'win W) -> Self {
         assert!(width > 0);
         assert!(height > 0);
 
         let size = SurfaceSize { width, height };
 
-        SurfaceTexture { window, size }
+        Self { window, size }
     }
 }
 
@@ -194,7 +194,7 @@ impl Pixels {
         width: u32,
         height: u32,
         surface_texture: SurfaceTexture<'_, W>,
-    ) -> Result<Pixels, Error> {
+    ) -> Result<Self, Error> {
         PixelsBuilder::new(width, height, surface_texture).build()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,7 +307,7 @@ impl Pixels {
     /// pixels.render()?;
     /// # Ok::<(), pixels::Error>(())
     /// ```
-    pub fn render(&mut self) -> Result<(), Error> {
+    pub fn render(&self) -> Result<(), Error> {
         self.render_with(|encoder, render_target, context| {
             context.scaling_renderer.render(encoder, render_target);
 
@@ -356,7 +356,7 @@ impl Pixels {
     /// })?;
     /// # Ok::<(), pixels::Error>(())
     /// ```
-    pub fn render_with<F>(&mut self, render_function: F) -> Result<(), Error>
+    pub fn render_with<F>(&self, render_function: F) -> Result<(), Error>
     where
         F: FnOnce(
             &mut wgpu::CommandEncoder,

--- a/src/renderers.rs
+++ b/src/renderers.rs
@@ -234,7 +234,7 @@ pub(crate) struct ScalingMatrix {
 impl ScalingMatrix {
     // texture_size is the dimensions of the drawing texture
     // screen_size is the dimensions of the surface being drawn to
-    pub(crate) fn new(texture_size: (f32, f32), screen_size: (f32, f32)) -> ScalingMatrix {
+    pub(crate) fn new(texture_size: (f32, f32), screen_size: (f32, f32)) -> Self {
         let (texture_width, texture_height) = texture_size;
         let (screen_width, screen_height) = screen_size;
 
@@ -270,7 +270,7 @@ impl ScalingMatrix {
             (x, y, scaled_width as u32, scaled_height as u32)
         };
 
-        ScalingMatrix {
+        Self {
             transform: Mat4::from(transform),
             clip_rect,
         }


### PR DESCRIPTION
Two changes here:

- Simplify constructor return types to use `Self` (non-breaking)
- Change render methods to shared borrow (breaking, but less restrictive ... should allow new ways to use the API, not fewer)