### PR TITLE
Simplify vertex attributes

### DIFF
--- a/examples/custom-shader/shaders/noise.wgsl
+++ b/examples/custom-shader/shaders/noise.wgsl
@@ -8,10 +8,9 @@ struct VertexOutput {
 [[stage(vertex)]]
 fn vs_main(
     [[location(0)]] position: vec2<f32>,
-    [[location(1)]] tex_coord: vec2<f32>,
 ) -> VertexOutput {
     var out: VertexOutput;
-    out.tex_coord = tex_coord;
+    out.tex_coord = position * vec2<f32>(0.5, -0.5) + 0.5;
     out.position = vec4<f32>(position, 0.0, 1.0);
     return out;
 }

--- a/examples/custom-shader/src/renderers.rs
+++ b/examples/custom-shader/src/renderers.rs
@@ -37,12 +37,12 @@ impl NoiseRenderer {
         });
 
         // Create vertex buffer; array-of-array of position and texture coordinates
-        let vertex_data: [[[f32; 2]; 2]; 3] = [
+        let vertex_data: [[f32; 2]; 3] = [
             // One full-screen triangle
             // See: https://github.com/parasyte/pixels/issues/180
-            [[-1.0, -1.0], [0.0, 0.0]],
-            [[3.0, -1.0], [2.0, 0.0]],
-            [[-1.0, 3.0], [0.0, 2.0]],
+            [-1.0, -1.0],
+            [3.0, -1.0],
+            [-1.0, 3.0],
         ];
         let vertex_data_slice = bytemuck::cast_slice(&vertex_data);
         let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
@@ -53,18 +53,11 @@ impl NoiseRenderer {
         let vertex_buffer_layout = wgpu::VertexBufferLayout {
             array_stride: (vertex_data_slice.len() / vertex_data.len()) as wgpu::BufferAddress,
             step_mode: wgpu::VertexStepMode::Vertex,
-            attributes: &[
-                wgpu::VertexAttribute {
-                    format: wgpu::VertexFormat::Float32x2,
-                    offset: 0,
-                    shader_location: 0,
-                },
-                wgpu::VertexAttribute {
-                    format: wgpu::VertexFormat::Float32x2,
-                    offset: 4 * 2,
-                    shader_location: 1,
-                },
-            ],
+            attributes: &[wgpu::VertexAttribute {
+                format: wgpu::VertexFormat::Float32x2,
+                offset: 0,
+                shader_location: 0,
+            }],
         };
 
         // Create uniform buffer

--- a/shaders/scale.wgsl
+++ b/shaders/scale.wgsl
@@ -15,7 +15,7 @@ fn vs_main(
     [[location(0)]] position: vec2<f32>,
 ) -> VertexOutput {
     var out: VertexOutput;
-    out.tex_coord = position * vec2<f32>(0.5, 0.5) + 0.5;
+    out.tex_coord = position * vec2<f32>(0.5, -0.5) + 0.5;
     out.position = r_locals.transform * vec4<f32>(position, 0.0, 1.0);
     return out;
 }

--- a/shaders/scale.wgsl
+++ b/shaders/scale.wgsl
@@ -15,7 +15,7 @@ fn vs_main(
     [[location(0)]] position: vec2<f32>,
 ) -> VertexOutput {
     var out: VertexOutput;
-    out.tex_coord = position * vec2<f32>(0.5, -0.5) + 0.5;
+    out.tex_coord = position * vec2<f32>(0.5, 0.5) + 0.5;
     out.position = r_locals.transform * vec4<f32>(position, 0.0, 1.0);
     return out;
 }

--- a/shaders/scale.wgsl
+++ b/shaders/scale.wgsl
@@ -13,10 +13,9 @@ struct VertexOutput {
 [[stage(vertex)]]
 fn vs_main(
     [[location(0)]] position: vec2<f32>,
-    [[location(1)]] tex_coord: vec2<f32>,
 ) -> VertexOutput {
     var out: VertexOutput;
-    out.tex_coord = tex_coord;
+    out.tex_coord = position * vec2<f32>(0.5, -0.5) + 0.5;
     out.position = r_locals.transform * vec4<f32>(position, 0.0, 1.0);
     return out;
 }

--- a/src/renderers.rs
+++ b/src/renderers.rs
@@ -248,9 +248,9 @@ impl ScalingMatrix {
         #[rustfmt::skip]
         let transform: [f32; 16] = [
             sw,  0.0, 0.0, 0.0,
-            0.0, -sh, 0.0, 0.0,
+            0.0, sh,  0.0, 0.0,
             0.0, 0.0, 1.0, 0.0,
-            tx,  ty, 0.0, 1.0,
+            tx,  ty,  0.0, 1.0,
         ];
 
         // Create a clipping rectangle

--- a/src/renderers.rs
+++ b/src/renderers.rs
@@ -42,12 +42,12 @@ impl ScalingRenderer {
         });
 
         // Create vertex buffer; array-of-array of position and texture coordinates
-        let vertex_data: [[[f32; 2]; 2]; 3] = [
+        let vertex_data: [[f32; 2]; 3] = [
             // One full-screen triangle
             // See: https://github.com/parasyte/pixels/issues/180
-            [[-1.0, -1.0], [0.0, 0.0]],
-            [[3.0, -1.0], [2.0, 0.0]],
-            [[-1.0, 3.0], [0.0, 2.0]],
+            [-1.0, -1.0],
+            [3.0, -1.0],
+            [-1.0, 3.0],
         ];
         let vertex_data_slice = bytemuck::cast_slice(&vertex_data);
         let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
@@ -58,18 +58,11 @@ impl ScalingRenderer {
         let vertex_buffer_layout = wgpu::VertexBufferLayout {
             array_stride: (vertex_data_slice.len() / vertex_data.len()) as wgpu::BufferAddress,
             step_mode: wgpu::VertexStepMode::Vertex,
-            attributes: &[
-                wgpu::VertexAttribute {
-                    format: wgpu::VertexFormat::Float32x2,
-                    offset: 0,
-                    shader_location: 0,
-                },
-                wgpu::VertexAttribute {
-                    format: wgpu::VertexFormat::Float32x2,
-                    offset: 4 * 2,
-                    shader_location: 1,
-                },
-            ],
+            attributes: &[wgpu::VertexAttribute {
+                format: wgpu::VertexFormat::Float32x2,
+                offset: 0,
+                shader_location: 0,
+            }],
         };
 
         // Create uniform buffer


### PR DESCRIPTION
- Vertex UVs can be computed from the positions, which saves a small
  amount of code and a small amount of bandwidth (both inconsequential).
- This is mostly for readability.