### PR TITLE
Revert Fused-Multiply-Add

### DIFF
--- a/examples/custom-shader/shaders/noise.wgsl
+++ b/examples/custom-shader/shaders/noise.wgsl
@@ -10,7 +10,7 @@ fn vs_main(
     [[location(0)]] position: vec2<f32>,
 ) -> VertexOutput {
     var out: VertexOutput;
-    out.tex_coord = fma(position, vec2<f32>(0.5, -0.5), vec2<f32>(0.5, 0.5));
+    out.tex_coord = position * vec2<f32>(0.5, -0.5) + 0.5;
     out.position = vec4<f32>(position, 0.0, 1.0);
     return out;
 }

--- a/shaders/scale.wgsl
+++ b/shaders/scale.wgsl
@@ -15,7 +15,7 @@ fn vs_main(
     [[location(0)]] position: vec2<f32>,
 ) -> VertexOutput {
     var out: VertexOutput;
-    out.tex_coord = fma(position, vec2<f32>(0.5, -0.5), vec2<f32>(0.5, 0.5));
+    out.tex_coord = position * vec2<f32>(0.5, -0.5) + 0.5;
     out.position = r_locals.transform * vec4<f32>(position, 0.0, 1.0);
     return out;
 }


### PR DESCRIPTION
This reverts commit bd2de37b84f0efba95468643d78a35a255040dc4.

There are some issues with FMA in the HLSL and GLES backends: https://github.com/gfx-rs/naga/pull/1580 Will revert-the-revert when it is supported everywhere.