### PR TITLE
Fix invalid texture sizes

### DIFF
--- a/examples/custom-shader/src/main.rs
+++ b/examples/custom-shader/src/main.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), Error> {
     };
     let mut world = World::new();
     let mut time = 0.0;
-    let mut noise_renderer = NoiseRenderer::new(&pixels, window_size.width, window_size.height);
+    let mut noise_renderer = NoiseRenderer::new(&pixels, window_size.width, window_size.height)?;
 
     event_loop.run(move |event, _, control_flow| {
         // Draw the current frame
@@ -64,10 +64,8 @@ fn main() -> Result<(), Error> {
                 Ok(())
             });
 
-            if render_result
-                .map_err(|e| error!("pixels.render_with() failed: {}", e))
-                .is_err()
-            {
+            if let Err(err) = render_result {
+                error!("pixels.render_with() failed: {err}");
                 *control_flow = ControlFlow::Exit;
                 return;
             }
@@ -83,8 +81,16 @@ fn main() -> Result<(), Error> {
 
             // Resize the window
             if let Some(size) = input.window_resized() {
-                pixels.resize_surface(size.width, size.height);
-                noise_renderer.resize(&pixels, size.width, size.height);
+                if let Err(err) = pixels.resize_surface(size.width, size.height) {
+                    error!("pixels.resize_surface() failed: {err}");
+                    *control_flow = ControlFlow::Exit;
+                    return;
+                }
+                if let Err(err) = noise_renderer.resize(&pixels, size.width, size.height) {
+                    error!("noise_renderer.resize() failed: {err}");
+                    *control_flow = ControlFlow::Exit;
+                    return;
+                }
             }
 
             // Update internal state and request a redraw

--- a/examples/imgui-winit/src/main.rs
+++ b/examples/imgui-winit/src/main.rs
@@ -76,10 +76,8 @@ fn main() -> Result<(), Error> {
             });
 
             // Basic error handling
-            if render_result
-                .map_err(|e| error!("pixels.render() failed: {}", e))
-                .is_err()
-            {
+            if let Err(err) = render_result {
+                error!("pixels.render() failed: {err}");
                 *control_flow = ControlFlow::Exit;
                 return;
             }
@@ -103,12 +101,20 @@ fn main() -> Result<(), Error> {
             if let Some(size) = input.window_resized() {
                 if size.width > 0 && size.height > 0 {
                     // Resize the surface texture
-                    pixels.resize_surface(size.width, size.height);
+                    if let Err(err) = pixels.resize_surface(size.width, size.height) {
+                        error!("pixels.resize_surface() failed: {err}");
+                        *control_flow = ControlFlow::Exit;
+                        return;
+                    }
 
                     // Resize the world
                     let LogicalSize { width, height } = size.to_logical(scale_factor);
                     world.resize(width, height);
-                    pixels.resize_buffer(width, height);
+                    if let Err(err) = pixels.resize_buffer(width, height) {
+                        error!("pixels.resize_buffer() failed: {err}");
+                        *control_flow = ControlFlow::Exit;
+                        return;
+                    }
                 }
             }
 

--- a/examples/invaders/src/main.rs
+++ b/examples/invaders/src/main.rs
@@ -140,8 +140,8 @@ fn main() -> Result<(), Error> {
         move |g| {
             // Drawing
             g.game.world.draw(g.game.pixels.get_frame_mut());
-            if let Err(e) = g.game.pixels.render() {
-                error!("pixels.render() failed: {}", e);
+            if let Err(err) = g.game.pixels.render() {
+                error!("pixels.render() failed: {err}");
                 g.exit();
             }
 
@@ -166,7 +166,10 @@ fn main() -> Result<(), Error> {
 
                 // Resize the window
                 if let Some(size) = g.game.input.window_resized() {
-                    g.game.pixels.resize_surface(size.width, size.height);
+                    if let Err(err) = g.game.pixels.resize_surface(size.width, size.height) {
+                        error!("pixels.resize_surface() failed: {err}");
+                        g.exit();
+                    }
                 }
             }
         },

--- a/examples/minimal-egui/src/main.rs
+++ b/examples/minimal-egui/src/main.rs
@@ -71,7 +71,11 @@ fn main() -> Result<(), Error> {
 
             // Resize the window
             if let Some(size) = input.window_resized() {
-                pixels.resize_surface(size.width, size.height);
+                if let Err(err) = pixels.resize_surface(size.width, size.height) {
+                    error!("pixels.resize_surface() failed: {err}");
+                    *control_flow = ControlFlow::Exit;
+                    return;
+                }
                 framework.resize(size.width, size.height);
             }
 
@@ -105,10 +109,8 @@ fn main() -> Result<(), Error> {
                 });
 
                 // Basic error handling
-                if render_result
-                    .map_err(|e| error!("pixels.render() failed: {}", e))
-                    .is_err()
-                {
+                if let Err(err) = render_result {
+                    error!("pixels.render() failed: {err}");
                     *control_flow = ControlFlow::Exit;
                 }
             }

--- a/examples/minimal-tao/src/main.rs
+++ b/examples/minimal-tao/src/main.rs
@@ -67,7 +67,10 @@ fn main() -> Result<(), Error> {
 
                 // Resize the window
                 WindowEvent::Resized(size) => {
-                    pixels.resize_surface(size.width, size.height);
+                    if let Err(err) = pixels.resize_surface(size.width, size.height) {
+                        error!("pixels.resize_surface() failed: {err}");
+                        *control_flow = ControlFlow::Exit;
+                    }
                 }
 
                 _ => {}
@@ -82,11 +85,8 @@ fn main() -> Result<(), Error> {
             // Draw the current frame
             Event::RedrawRequested(_) => {
                 world.draw(pixels.get_frame_mut());
-                if pixels
-                    .render()
-                    .map_err(|e| error!("pixels.render() failed: {}", e))
-                    .is_err()
-                {
+                if let Err(err) = pixels.render() {
+                    error!("pixels.render() failed: {err}");
                     *control_flow = ControlFlow::Exit;
                 }
             }

--- a/examples/minimal-web/src/main.rs
+++ b/examples/minimal-web/src/main.rs
@@ -111,11 +111,8 @@ async fn run() {
         // Draw the current frame
         if let Event::RedrawRequested(_) = event {
             world.draw(pixels.get_frame_mut());
-            if pixels
-                .render()
-                .map_err(|e| error!("pixels.render() failed: {}", e))
-                .is_err()
-            {
+            if let Err(err) = pixels.render() {
+                error!("pixels.render() failed: {err}");
                 *control_flow = ControlFlow::Exit;
                 return;
             }
@@ -131,7 +128,11 @@ async fn run() {
 
             // Resize the window
             if let Some(size) = input.window_resized() {
-                pixels.resize_surface(size.width, size.height);
+                if let Err(err) = pixels.resize_surface(size.width, size.height) {
+                    error!("pixels.resize_surface() failed: {err}");
+                    *control_flow = ControlFlow::Exit;
+                    return;
+                }
             }
 
             // Update internal state and request a redraw

--- a/examples/minimal-winit/src/main.rs
+++ b/examples/minimal-winit/src/main.rs
@@ -46,11 +46,8 @@ fn main() -> Result<(), Error> {
         // Draw the current frame
         if let Event::RedrawRequested(_) = event {
             world.draw(pixels.get_frame_mut());
-            if pixels
-                .render()
-                .map_err(|e| error!("pixels.render() failed: {}", e))
-                .is_err()
-            {
+            if let Err(err) = pixels.render() {
+                error!("pixels.render() failed: {err}");
                 *control_flow = ControlFlow::Exit;
                 return;
             }
@@ -66,7 +63,11 @@ fn main() -> Result<(), Error> {
 
             // Resize the window
             if let Some(size) = input.window_resized() {
-                pixels.resize_surface(size.width, size.height);
+                if let Err(err) = pixels.resize_surface(size.width, size.height) {
+                    error!("pixels.resize_surface() failed: {err}");
+                    *control_flow = ControlFlow::Exit;
+                    return;
+                }
             }
 
             // Update internal state and request a redraw

--- a/examples/raqote-winit/src/main.rs
+++ b/examples/raqote-winit/src/main.rs
@@ -56,11 +56,8 @@ fn main() -> Result<(), Error> {
                 dst[3] = (src >> 24) as u8;
             }
 
-            if pixels
-                .render()
-                .map_err(|e| error!("pixels.render() failed: {}", e))
-                .is_err()
-            {
+            if let Err(err) = pixels.render() {
+                error!("pixels.render() failed: {err}");
                 *control_flow = ControlFlow::Exit;
                 return;
             }
@@ -76,7 +73,11 @@ fn main() -> Result<(), Error> {
 
             // Resize the window
             if let Some(size) = input.window_resized() {
-                pixels.resize_surface(size.width, size.height);
+                if let Err(err) = pixels.resize_surface(size.width, size.height) {
+                    error!("pixels.resize_surface() failed: {err}");
+                    *control_flow = ControlFlow::Exit;
+                    return;
+                }
             }
 
             // Update internal state and request a redraw

--- a/examples/tiny-skia-winit/src/main.rs
+++ b/examples/tiny-skia-winit/src/main.rs
@@ -44,11 +44,8 @@ fn main() -> Result<(), Error> {
         // Draw the current frame
         if let Event::RedrawRequested(_) = event {
             pixels.get_frame_mut().copy_from_slice(drawing.data());
-            if pixels
-                .render()
-                .map_err(|e| error!("pixels.render() failed: {}", e))
-                .is_err()
-            {
+            if let Err(err) = pixels.render() {
+                error!("pixels.render() failed: {err}");
                 *control_flow = ControlFlow::Exit;
                 return;
             }
@@ -64,7 +61,11 @@ fn main() -> Result<(), Error> {
 
             // Resize the window
             if let Some(size) = input.window_resized() {
-                pixels.resize_surface(size.width, size.height);
+                if let Err(err) = pixels.resize_surface(size.width, size.height) {
+                    error!("pixels.resize_surface() failed: {err}");
+                    *control_flow = ControlFlow::Exit;
+                    return;
+                }
             }
 
             // Update internal state and request a redraw

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,6 +1,5 @@
 use crate::renderers::{ScalingMatrix, ScalingRenderer};
-use crate::SurfaceSize;
-use crate::{Error, Pixels, PixelsContext, SurfaceTexture};
+use crate::{Error, Pixels, PixelsContext, SurfaceSize, SurfaceTexture, TextureError};
 use raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle};
 
 /// A builder to help create customized pixel buffers.
@@ -321,7 +320,7 @@ impl<'req, 'dev, 'win, W: HasRawWindowHandle + HasRawDisplayHandle>
                 render_texture_format,
                 clear_color,
                 blend_state,
-            );
+            )?;
 
         // Create the pixel buffer
         let mut pixels = Vec::with_capacity(pixels_buffer_size);
@@ -397,6 +396,28 @@ impl<'req, 'dev, 'win, W: HasRawWindowHandle + HasRawDisplayHandle>
     }
 }
 
+/// Compare the given size to the limits defined by `device`.
+///
+/// # Errors
+///
+/// - [`TextureError::TextureWidth`] when `width` is 0 or greater than GPU texture limits.
+/// - [`TextureError::TextureHeight`] when `height` is 0 or greater than GPU texture limits.
+pub fn check_texture_size(
+    device: &wgpu::Device,
+    width: u32,
+    height: u32,
+) -> Result<(), TextureError> {
+    let limits = device.limits();
+    if width == 0 || width > limits.max_texture_dimension_2d {
+        return Err(TextureError::TextureWidth(width));
+    }
+    if height == 0 || height > limits.max_texture_dimension_2d {
+        return Err(TextureError::TextureHeight(height));
+    }
+
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn create_backing_texture(
     device: &wgpu::Device,
@@ -407,13 +428,18 @@ pub(crate) fn create_backing_texture(
     render_texture_format: wgpu::TextureFormat,
     clear_color: wgpu::Color,
     blend_state: wgpu::BlendState,
-) -> (
-    ultraviolet::Mat4,
-    wgpu::Extent3d,
-    wgpu::Texture,
-    ScalingRenderer,
-    usize,
-) {
+) -> Result<
+    (
+        ultraviolet::Mat4,
+        wgpu::Extent3d,
+        wgpu::Texture,
+        ScalingRenderer,
+        usize,
+    ),
+    TextureError,
+> {
+    check_texture_size(device, width, height)?;
+
     let scaling_matrix_inverse = ScalingMatrix::new(
         (width as f32, height as f32),
         (surface_size.width as f32, surface_size.height as f32),
@@ -451,13 +477,13 @@ pub(crate) fn create_backing_texture(
     let texture_format_size = get_texture_format_size(backing_texture_format);
     let pixels_buffer_size = ((width * height) as f32 * texture_format_size) as usize;
 
-    (
+    Ok((
         scaling_matrix_inverse,
         texture_extent,
         texture,
         scaling_renderer,
         pixels_buffer_size,
-    )
+    ))
 }
 
 #[rustfmt::skip]


### PR DESCRIPTION
- Makes methods fallible when they create textures.
- Breaking changes:
  - `Pixels::Error` is now marked `#[non_exhaustive]`
  - `Pixels::resize_buffer()` and `Pixels::resize_surface()` return `Result<_, TextureError>`.
  - `Pixels::resize_buffer()` no longer panics on invalid inputs.
- Correctly handle window resize in fltk example.
- TODO: tests
- Closes #240

I haven't written any tests for this, because I still don't have a great solution to the issue raised in #80.

This does add a lot of noise to the examples. I can perhaps address some of that with `Result` transformation methods. The "print error and exit event loop" pattern is very common in these examples but might need more intelligent handling in a real application.