### PR TITLE
Make BlendState configurable

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -391,6 +391,7 @@ impl<'req, 'dev, 'win, W: HasRawWindowHandle> PixelsBuilder<'req, 'dev, 'win, W>
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn create_backing_texture(
     device: &wgpu::Device,
     width: u32,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -193,7 +193,7 @@ impl<'req, 'dev, 'win, W: HasRawWindowHandle> PixelsBuilder<'req, 'dev, 'win, W>
 
     /// Set the blend state.
     ///
-    /// Allows customization of how to mix the new and new existing pixels in a texture
+    /// Allows customization of how to mix the new and existing pixels in a texture
     /// when rendering.
     ///
     /// The default blend state is alpha blending with non-premultiplied alpha.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ pub struct Pixels {
     present_mode: wgpu::PresentMode,
     render_texture_format: wgpu::TextureFormat,
     surface_texture_format: wgpu::TextureFormat,
+    blend_state: wgpu::BlendState,
 
     // Pixel buffer
     pixels: Vec<u8>,
@@ -285,6 +286,7 @@ impl Pixels {
                 &self.surface_size,
                 self.render_texture_format,
                 self.context.scaling_renderer.clear_color,
+                self.blend_state,
             );
 
         self.scaling_matrix_inverse = scaling_matrix_inverse;

--- a/src/renderers.rs
+++ b/src/renderers.rs
@@ -23,6 +23,7 @@ impl ScalingRenderer {
         surface_size: &SurfaceSize,
         render_texture_format: wgpu::TextureFormat,
         clear_color: wgpu::Color,
+        blend_state: wgpu::BlendState,
     ) -> Self {
         let shader = wgpu::include_wgsl!("../shaders/scale.wgsl");
         let module = device.create_shader_module(&shader);
@@ -152,7 +153,7 @@ impl ScalingRenderer {
                 entry_point: "fs_main",
                 targets: &[wgpu::ColorTargetState {
                     format: render_texture_format,
-                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    blend: Some(blend_state),
                     write_mask: wgpu::ColorWrites::ALL,
                 }],
             }),


### PR DESCRIPTION
Makes the BlendState configurable so I can use the alpha channel as a flag for a custom shader.

I also reworded the documentation for clear_color a bit.

I checked and it works correctly, but let me know if I'm not threading the blend_state through each struct correctly.