### PR TITLE
Allow accessing frame on immutable buffer

### DIFF
--- a/examples/conway/src/main.rs
+++ b/examples/conway/src/main.rs
@@ -44,7 +44,7 @@ fn main() -> Result<(), Error> {
     event_loop.run(move |event, _, control_flow| {
         // The one and only event that winit_input_helper doesn't have for us...
         if let Event::RedrawRequested(_) = event {
-            life.draw(pixels.get_frame());
+            life.draw(pixels.get_frame_mut());
             if pixels
                 .render()
                 .map_err(|e| error!("pixels.render() failed: {}", e))

--- a/examples/custom-shader/src/main.rs
+++ b/examples/custom-shader/src/main.rs
@@ -50,7 +50,7 @@ fn main() -> Result<(), Error> {
     event_loop.run(move |event, _, control_flow| {
         // Draw the current frame
         if let Event::RedrawRequested(_) = event {
-            world.draw(pixels.get_frame());
+            world.draw(pixels.get_frame_mut());
 
             let render_result = pixels.render_with(|encoder, render_target, context| {
                 let noise_texture = noise_renderer.get_texture_view();

--- a/examples/imgui-winit/src/main.rs
+++ b/examples/imgui-winit/src/main.rs
@@ -59,7 +59,7 @@ fn main() -> Result<(), Error> {
         // Draw the current frame
         if let Event::RedrawRequested(_) = event {
             // Draw the world
-            world.draw(pixels.get_frame());
+            world.draw(pixels.get_frame_mut());
 
             // Prepare Dear ImGui
             gui.prepare(&window).expect("gui.prepare() failed");

--- a/examples/invaders/src/main.rs
+++ b/examples/invaders/src/main.rs
@@ -139,7 +139,7 @@ fn main() -> Result<(), Error> {
         },
         move |g| {
             // Drawing
-            g.game.world.draw(g.game.pixels.get_frame());
+            g.game.world.draw(g.game.pixels.get_frame_mut());
             if let Err(e) = g.game.pixels.render() {
                 error!("pixels.render() failed: {}", e);
                 g.exit();

--- a/examples/minimal-egui/src/main.rs
+++ b/examples/minimal-egui/src/main.rs
@@ -83,7 +83,7 @@ fn main() -> Result<(), Error> {
             // Draw the current frame
             Event::RedrawRequested(_) => {
                 // Draw the world
-                world.draw(pixels.get_frame());
+                world.draw(pixels.get_frame_mut());
 
                 // Prepare egui
                 framework.prepare(&window);

--- a/examples/minimal-fltk/src/main.rs
+++ b/examples/minimal-fltk/src/main.rs
@@ -50,7 +50,7 @@ fn main() -> Result<(), Error> {
         world.update();
 
         // Draw the current frame
-        world.draw(pixels.get_frame());
+        world.draw(pixels.get_frame_mut());
         if pixels
             .render()
             .map_err(|e| error!("pixels.render() failed: {}", e))

--- a/examples/minimal-sdl2/src/main.rs
+++ b/examples/minimal-sdl2/src/main.rs
@@ -61,7 +61,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         world.update();
 
         // Draw the current frame
-        world.draw(pixels.get_frame());
+        world.draw(pixels.get_frame_mut());
         pixels.render()?;
     }
 

--- a/examples/minimal-web/src/main.rs
+++ b/examples/minimal-web/src/main.rs
@@ -110,7 +110,7 @@ async fn run() {
     event_loop.run(move |event, _, control_flow| {
         // Draw the current frame
         if let Event::RedrawRequested(_) = event {
-            world.draw(pixels.get_frame());
+            world.draw(pixels.get_frame_mut());
             if pixels
                 .render()
                 .map_err(|e| error!("pixels.render() failed: {}", e))

--- a/examples/minimal-winit/src/main.rs
+++ b/examples/minimal-winit/src/main.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), Error> {
     event_loop.run(move |event, _, control_flow| {
         // Draw the current frame
         if let Event::RedrawRequested(_) = event {
-            world.draw(pixels.get_frame());
+            world.draw(pixels.get_frame_mut());
             if pixels
                 .render()
                 .map_err(|e| error!("pixels.render() failed: {}", e))

--- a/examples/raqote-winit/src/main.rs
+++ b/examples/raqote-winit/src/main.rs
@@ -46,7 +46,7 @@ fn main() -> Result<(), Error> {
         // Draw the current frame
         if let Event::RedrawRequested(_) = event {
             for (dst, &src) in pixels
-                .get_frame()
+                .get_frame_mut()
                 .chunks_exact_mut(4)
                 .zip(shapes.get_frame().iter())
             {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,8 +497,8 @@ impl Pixels {
         &mut self.pixels
     }
 
-    /// Get an immutable byte slice for the pixel buffer. The buffer is _not_ cleared for you; it will
-    /// retain the previous frame's contents until you clear it yourself.
+    /// Get an immutable byte slice for the pixel buffer. The buffer is _not_ cleared for you; it
+    /// will retain the previous frame's contents until you clear it yourself.
     pub fn get_frame(&self) -> &[u8] {
         &self.pixels
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,6 +497,12 @@ impl Pixels {
         &mut self.pixels
     }
 
+    /// Get an immutable byte slice for the pixel buffer. The buffer is _not_ cleared for you; it will
+    /// retain the previous frame's contents until you clear it yourself.
+    pub fn get_frame_immut(&self) -> &[u8] {
+        &self.pixels
+    }
+
     /// Calculate the pixel location from a physical location on the window,
     /// dealing with window resizing, scaling, and margins. Takes a physical
     /// position (x, y) within the window, and returns a pixel position (x, y).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -500,7 +500,7 @@ impl Pixels {
     /// Get an immutable byte slice for the pixel buffer.
     ///
     /// This may be useful for operations that must sample the buffer, such as blending pixel
-    /// colours directly into the buffer.
+    /// colours directly into it.
     pub fn get_frame(&self) -> &[u8] {
         &self.pixels
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,7 +354,7 @@ impl Pixels {
     /// let mut pixels = Pixels::new(320, 240, surface_texture)?;
     ///
     /// // Clear the pixel buffer
-    /// let frame = pixels.get_frame();
+    /// let frame = pixels.get_frame_mut();
     /// for pixel in frame.chunks_exact_mut(4) {
     ///     pixel[0] = 0x00; // R
     ///     pixel[1] = 0x00; // G
@@ -399,7 +399,7 @@ impl Pixels {
     /// let mut pixels = Pixels::new(320, 240, surface_texture)?;
     ///
     /// // Clear the pixel buffer
-    /// let frame = pixels.get_frame();
+    /// let frame = pixels.get_frame_mut();
     /// for pixel in frame.chunks_exact_mut(4) {
     ///     pixel[0] = 0x00; // R
     ///     pixel[1] = 0x00; // G
@@ -493,13 +493,13 @@ impl Pixels {
 
     /// Get a mutable byte slice for the pixel buffer. The buffer is _not_ cleared for you; it will
     /// retain the previous frame's contents until you clear it yourself.
-    pub fn get_frame(&mut self) -> &mut [u8] {
+    pub fn get_frame_mut(&mut self) -> &mut [u8] {
         &mut self.pixels
     }
 
     /// Get an immutable byte slice for the pixel buffer. The buffer is _not_ cleared for you; it will
     /// retain the previous frame's contents until you clear it yourself.
-    pub fn get_frame_immut(&self) -> &[u8] {
+    pub fn get_frame(&self) -> &[u8] {
         &self.pixels
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,8 +497,10 @@ impl Pixels {
         &mut self.pixels
     }
 
-    /// Get an immutable byte slice for the pixel buffer. The buffer is _not_ cleared for you; it
-    /// will retain the previous frame's contents until you clear it yourself.
+    /// Get an immutable byte slice for the pixel buffer.
+    ///
+    /// This may be useful for operations that must sample the buffer, such as blending pixel
+    /// colours directly into the buffer.
     pub fn get_frame(&self) -> &[u8] {
         &self.pixels
     }


### PR DESCRIPTION
I have a trait like the following:
```rs
pub trait Buffer {
    /// Returns the size of the buffer.
    fn size(&self) -> Size;

    /// Returns a copy of the pixel data for the given coordinates, or `None` if no such pixel
    /// exists.
    fn pixel_chunk(&self, x: u32, y: u32) -> Option<[u8; 4]>;

    /// Returns a mutable reference to the pixel data for the given coordinates, or `None` if no
    /// such pixel exists.
    fn pixel_chunk_mut(&mut self, x: u32, y: u32) -> Option<&mut [u8]>;

    // -snip-
}
```
I do not know what users of the trait will do with the values returned from `pixel_chunk`, but any implementation of this trait that is built on top of a `Pixels` instance will not be able to implement `pixel_chunk` without having some sort of interior mutability in place because `Pixels::get_frame` only takes `&mut self` because it returns a mutable reference.

This pull request adds another method, `get_frame_immut`, that returns an immutable reference to the underlying frame, so that users can access the pixel data without needing a mutable reference to the `Pixels` structure that holds it.

For naming, I would have preferred that the original method was `get_frame_mut` and the new one just `get_frame`, but I've instead used `get_frame_immut` because `get_frame` is such an integral method to using this library, so renaming it would break a lot of code (and cause confusion because of the different mutability on the new method's return value).