### PR TITLE
Remove the exposed web feature

### DIFF
--- a/examples/minimal-web/Cargo.toml
+++ b/examples/minimal-web/Cargo.toml
@@ -7,13 +7,11 @@ publish = false
 
 [features]
 optimize = ["log/release_max_level_warn"]
-web = ["wgpu/webgl"]
 default = ["optimize"]
 
 [dependencies]
 log = "0.4"
 pixels = { path = "../.." }
-wgpu = "0.13"
 winit = "0.26"
 winit_input_helper = "0.12"
 
@@ -23,6 +21,7 @@ console_log = "0.2"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 web-sys = "0.3"
+wgpu = { version = "0.13", features = ["webgl"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = "0.9"

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ serve package: (build package)
 build package:
     mkdir -p ./target/{{package}}/
     cp ./examples/{{package}}/index.html ./target/{{package}}/
-    cargo build --release --package {{package}} --target wasm32-unknown-unknown --features web
+    cargo build --release --package {{package}} --target wasm32-unknown-unknown
     wasm-bindgen --target web --no-typescript --out-dir ./target/{{package}}/ ./target/wasm32-unknown-unknown/release/{{package}}.wasm
 
 clean package:


### PR DESCRIPTION
- The `web` feature was previously exposed by the example crate. This isn't really necessary.
- See #276 for discussion