### PR TITLE
Fix minimal-egui rendering

### DIFF
--- a/examples/minimal-egui/src/gui.rs
+++ b/examples/minimal-egui/src/gui.rs
@@ -118,7 +118,7 @@ impl Framework {
                     view: render_target,
                     resolve_target: None,
                     ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        load: wgpu::LoadOp::Load,
                         store: true,
                     },
                 })],


### PR DESCRIPTION
This example was showing a black screen behind the GUI. The bug was introduced in #320.