### PR TITLE
Fix validation errors with WebGL2 backend

### DIFF
--- a/examples/custom-shader/src/renderers.rs
+++ b/examples/custom-shader/src/renderers.rs
@@ -229,10 +229,7 @@ fn create_texture_view(
         dimension: wgpu::TextureDimension::D2,
         format: pixels.render_texture_format(),
         usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::RENDER_ATTACHMENT,
-        view_formats: &[
-            pixels.render_texture_format().add_srgb_suffix(),
-            pixels.render_texture_format().remove_srgb_suffix(),
-        ],
+        view_formats: &[pixels.render_texture_format().add_srgb_suffix()],
     };
 
     Ok(device

--- a/examples/custom-shader/src/renderers.rs
+++ b/examples/custom-shader/src/renderers.rs
@@ -229,7 +229,7 @@ fn create_texture_view(
         dimension: wgpu::TextureDimension::D2,
         format: pixels.render_texture_format(),
         usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::RENDER_ATTACHMENT,
-        view_formats: &[pixels.render_texture_format().add_srgb_suffix()],
+        view_formats: &[],
     };
 
     Ok(device

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -464,10 +464,7 @@ pub(crate) fn create_backing_texture(
         dimension: wgpu::TextureDimension::D2,
         format: backing_texture_format,
         usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
-        view_formats: &[
-            backing_texture_format.add_srgb_suffix(),
-            backing_texture_format.remove_srgb_suffix(),
-        ],
+        view_formats: &[backing_texture_format.add_srgb_suffix()],
     });
     let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -464,7 +464,7 @@ pub(crate) fn create_backing_texture(
         dimension: wgpu::TextureDimension::D2,
         format: backing_texture_format,
         usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
-        view_formats: &[backing_texture_format.add_srgb_suffix()],
+        view_formats: &[],
     });
     let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -512,7 +512,7 @@ impl Pixels {
                 height: self.surface_size.height,
                 present_mode: self.present_mode,
                 alpha_mode: self.alpha_mode,
-                view_formats: vec![self.surface_texture_format.add_srgb_suffix()],
+                view_formats: vec![],
             },
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -512,10 +512,7 @@ impl Pixels {
                 height: self.surface_size.height,
                 present_mode: self.present_mode,
                 alpha_mode: self.alpha_mode,
-                view_formats: vec![
-                    self.surface_texture_format.add_srgb_suffix(),
-                    self.surface_texture_format.remove_srgb_suffix(),
-                ],
+                view_formats: vec![self.surface_texture_format.add_srgb_suffix()],
             },
         );
     }


### PR DESCRIPTION
- We should be able to allow linear-space texture views, but these are not available on WebGL2.
- Support only sRGB-space texture views for now.