### PR TITLE
Add `wgpu::Adapter` API to users

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -345,6 +345,7 @@ impl<'req, 'dev, 'win, W: HasRawWindowHandle + HasRawDisplayHandle>
 
         let pixels = Pixels {
             context,
+            adapter,
             surface_size,
             present_mode,
             render_texture_format,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,12 +284,13 @@ impl Pixels {
     /// use pixels::Pixels;
     /// 
     /// let mut pixels = Pixels::new(320, 240, surface_texture)?;
-    /// let adapter = pixels.get_wgpu_adapter();
+    /// let adapter = pixels.adapter();
     /// // Do something with the adapter.
     /// ```
-    pub fn get_wgpu_adapter(&self) -> &wgpu::Adapter {
+    pub fn adapter(&self) -> &wgpu::Adapter {
         &self.adapter
     }
+
     /// Resize the pixel buffer and zero its contents.
     ///
     /// This does not resize the surface upon which the pixel buffer texture is rendered. Use

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,12 +280,15 @@ impl Pixels {
     ///
     /// The adapter can be used to retrieve runtime information about the host system
     /// or the WGPU backend.
-    /// ```no_run
-    /// use pixels::Pixels;
     ///
+    /// ```no_run
+    /// # use pixels::Pixels;
+    /// # let window = pixels_mocks::Rwh;
+    /// # let surface_texture = pixels::SurfaceTexture::new(320, 240, &window);
     /// let mut pixels = Pixels::new(320, 240, surface_texture)?;
     /// let adapter = pixels.adapter();
     /// // Do something with the adapter.
+    /// # Ok::<(), pixels::Error>(())
     /// ```
     pub fn adapter(&self) -> &wgpu::Adapter {
         &self.adapter

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,12 +277,12 @@ impl Pixels {
     }
 
     /// Returns a reference of the `wgpu` adapter used by the crate.
-    /// 
+    ///
     /// The adapter can be used to retrieve runtime information about the host system
     /// or the WGPU backend.
     /// ```no_run
     /// use pixels::Pixels;
-    /// 
+    ///
     /// let mut pixels = Pixels::new(320, 240, surface_texture)?;
     /// let adapter = pixels.adapter();
     /// // Do something with the adapter.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,22 +290,6 @@ impl Pixels {
     pub fn get_wgpu_adapter(&self) -> &wgpu::Adapter {
         &self.adapter
     }
-
-    /// Returns a mutable reference to the `wgpu` adapter used by the crate.
-    /// 
-    /// The adapter can be used to retrieve runtime information about the host system
-    /// or the WGPU backend.
-    /// ```no_run
-    /// use pixels::Pixels;
-    /// 
-    /// let mut pixels = Pixels::new(320, 240, surface_texture)?;
-    /// let adapter = pixels.get_wgpu_adapter();
-    /// // Do something with the adapter.
-    /// ```
-    pub fn get_wgpu_adapter_mut(&mut self) -> &mut wgpu::Adapter {
-        &mut self.adapter
-    }
-
     /// Resize the pixel buffer and zero its contents.
     ///
     /// This does not resize the surface upon which the pixel buffer texture is rendered. Use

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@ pub struct Pixels {
     surface_texture_format: wgpu::TextureFormat,
     blend_state: wgpu::BlendState,
     alpha_mode: wgpu::CompositeAlphaMode,
+    adapter: wgpu::Adapter,
 
     // Pixel buffer
     pixels: Vec<u8>,
@@ -273,6 +274,21 @@ impl Pixels {
     /// ```
     pub fn set_clear_color(&mut self, color: wgpu::Color) {
         self.context.scaling_renderer.clear_color = color;
+    }
+
+    /// Returns a reference the `wgpu` adapter used by the crate.
+    /// 
+    /// The adapter can be used to retrieve runtime information about the host system
+    /// or the WGPU backend.
+    /// ```no_run
+    /// use pixels::Pixels;
+    /// 
+    /// let mut pixels = Pixels::new(320, 240, surface_texture)?;
+    /// let adapter = pixels.get_wgpu_adapter();
+    /// // Do something with the adapter.
+    /// ```
+    pub fn get_wgpu_adapter(&self) -> &wgpu::Adapter {
+        &self.adapter
     }
 
     /// Resize the pixel buffer and zero its contents.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,7 +276,7 @@ impl Pixels {
         self.context.scaling_renderer.clear_color = color;
     }
 
-    /// Returns a reference the `wgpu` adapter used by the crate.
+    /// Returns a reference of the `wgpu` adapter used by the crate.
     /// 
     /// The adapter can be used to retrieve runtime information about the host system
     /// or the WGPU backend.
@@ -289,6 +289,21 @@ impl Pixels {
     /// ```
     pub fn get_wgpu_adapter(&self) -> &wgpu::Adapter {
         &self.adapter
+    }
+
+    /// Returns a mutable reference to the `wgpu` adapter used by the crate.
+    /// 
+    /// The adapter can be used to retrieve runtime information about the host system
+    /// or the WGPU backend.
+    /// ```no_run
+    /// use pixels::Pixels;
+    /// 
+    /// let mut pixels = Pixels::new(320, 240, surface_texture)?;
+    /// let adapter = pixels.get_wgpu_adapter();
+    /// // Do something with the adapter.
+    /// ```
+    pub fn get_wgpu_adapter_mut(&mut self) -> &mut wgpu::Adapter {
+        &mut self.adapter
     }
 
     /// Resize the pixel buffer and zero its contents.


### PR DESCRIPTION
"Closes" #339 

There's also the alternative of strictly exposing only `wgpu::AdapterInfo`. Which may be desired if we don't want to give any access to the adapter itself for whatever reason (Keep in mind with the commits as they are currently we give at most a mutable ref to the adapter, which may allow someone to modify things they shouldn't). I avoided this because why hide a simple adapter when the crate exposes other parts of `wgpu`? And at worst, let users decide if they want to get access to the adapter.

If the function names aren't good (eg. _wgpu_ shouldn't be there) or we need to wrap around `wgpu::Adapter` then lmk, I'll fix it.\
Verified to work under GNU/Linux as expected.