### PR TITLE
Make Rust standard library optional (WIP)

### DIFF
--- a/examples/invaders/simple-invaders/src/collision.rs
+++ b/examples/invaders/simple-invaders/src/collision.rs
@@ -2,17 +2,17 @@
 
 use crate::geo::{Point, Rect};
 use crate::{Bullet, Invaders, Laser, Player, Shield, COLS, GRID, ROWS};
-use std::collections::HashSet;
+use alloc::collections::BTreeSet;
 
 /// Store information about collisions (for debug mode).
 #[derive(Debug, Default)]
 pub(crate) struct Collision {
-    pub(crate) bullet_details: HashSet<BulletDetail>,
-    pub(crate) laser_details: HashSet<LaserDetail>,
+    pub(crate) bullet_details: BTreeSet<BulletDetail>,
+    pub(crate) laser_details: BTreeSet<LaserDetail>,
 }
 
 /// Information regarding collisions between bullets and invaders, lasers, or shields.
-#[derive(Debug, Eq, Hash, PartialEq)]
+#[derive(Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub(crate) enum BulletDetail {
     /// A grid position (col, row) for an invader.
     Invader(usize, usize),
@@ -23,7 +23,7 @@ pub(crate) enum BulletDetail {
 }
 
 /// Information regarding collisions between lasers and shields or the player.
-#[derive(Debug, Eq, Hash, PartialEq)]
+#[derive(Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub(crate) enum LaserDetail {
     /// A shield index.
     Shield(usize),

--- a/examples/invaders/simple-invaders/src/geo.rs
+++ b/examples/invaders/simple-invaders/src/geo.rs
@@ -23,7 +23,7 @@ impl Point {
     }
 }
 
-impl std::ops::Add for Point {
+impl core::ops::Add for Point {
     type Output = Self;
 
     fn add(self, other: Self) -> Self {
@@ -31,7 +31,7 @@ impl std::ops::Add for Point {
     }
 }
 
-impl std::ops::Mul for Point {
+impl core::ops::Mul for Point {
     type Output = Self;
 
     fn mul(self, other: Self) -> Self {

--- a/examples/invaders/simple-invaders/src/lib.rs
+++ b/examples/invaders/simple-invaders/src/lib.rs
@@ -4,8 +4,12 @@
 //! this in practice. That said, the game is fully functional, and it should not be too difficult
 //! to understand the code.
 
+#![no_std]
 #![deny(clippy::all)]
 #![forbid(unsafe_code)]
+
+extern crate alloc;
+use alloc::vec::Vec;
 
 use crate::collision::Collision;
 pub use crate::controls::{Controls, Direction};
@@ -13,7 +17,7 @@ use crate::geo::Point;
 use crate::loader::{load_assets, Assets};
 use crate::sprites::{blit, Animation, Drawable, Frame, Sprite, SpriteRef};
 use randomize::PCG32;
-use std::time::Duration;
+use core::time::Duration;
 
 mod collision;
 mod controls;

--- a/examples/invaders/simple-invaders/src/lib.rs
+++ b/examples/invaders/simple-invaders/src/lib.rs
@@ -16,8 +16,8 @@ pub use crate::controls::{Controls, Direction};
 use crate::geo::Point;
 use crate::loader::{load_assets, Assets};
 use crate::sprites::{blit, Animation, Drawable, Frame, Sprite, SpriteRef};
-use randomize::PCG32;
 use core::time::Duration;
+use randomize::PCG32;
 
 mod collision;
 mod controls;

--- a/examples/invaders/simple-invaders/src/loader.rs
+++ b/examples/invaders/simple-invaders/src/loader.rs
@@ -1,6 +1,7 @@
-use std::collections::HashMap;
-use std::io::Cursor;
-use std::rc::Rc;
+use alloc::collections::BTreeMap;
+use alloc::rc::Rc;
+
+use alloc::vec::Vec;
 
 use crate::sprites::{CachedSprite, Frame};
 
@@ -8,11 +9,11 @@ use crate::sprites::{CachedSprite, Frame};
 #[derive(Debug)]
 pub(crate) struct Assets {
     // sounds: TODO
-    sprites: HashMap<Frame, CachedSprite>,
+    sprites: BTreeMap<Frame, CachedSprite>,
 }
 
 impl Assets {
-    pub(crate) fn sprites(&self) -> &HashMap<Frame, CachedSprite> {
+    pub(crate) fn sprites(&self) -> &BTreeMap<Frame, CachedSprite> {
         &self.sprites
     }
 }
@@ -21,7 +22,7 @@ impl Assets {
 pub(crate) fn load_assets() -> Assets {
     use Frame::*;
 
-    let mut sprites = HashMap::new();
+    let mut sprites = BTreeMap::new();
 
     sprites.insert(Blipjoy1, load_pcx(include_bytes!("assets/blipjoy1.pcx")));
     sprites.insert(Blipjoy2, load_pcx(include_bytes!("assets/blipjoy2.pcx")));
@@ -57,7 +58,7 @@ pub(crate) fn load_assets() -> Assets {
 
 /// Convert PCX data to raw pixels
 fn load_pcx(pcx: &[u8]) -> CachedSprite {
-    let mut reader = pcx::Reader::new(Cursor::new(pcx)).unwrap();
+    let mut reader = pcx::Reader::new(pcx).unwrap();
     let width = reader.width() as usize;
     let height = reader.height() as usize;
     let mut result = Vec::new();
@@ -113,6 +114,8 @@ fn load_pcx(pcx: &[u8]) -> CachedSprite {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+
     use super::*;
 
     #[test]

--- a/examples/invaders/simple-invaders/src/sprites.rs
+++ b/examples/invaders/simple-invaders/src/sprites.rs
@@ -1,11 +1,11 @@
 use crate::loader::Assets;
 use crate::TIME_STEP;
 use crate::{Point, HEIGHT, WIDTH};
-use alloc::vec::Vec;
-use line_drawing::Bresenham;
-use core::cmp::min;
 use alloc::rc::Rc;
+use alloc::vec::Vec;
+use core::cmp::min;
 use core::time::Duration;
+use line_drawing::Bresenham;
 
 // This is the type stored in the `Assets` hash map
 pub(crate) type CachedSprite = (usize, usize, Rc<[u8]>);

--- a/examples/invaders/simple-invaders/src/sprites.rs
+++ b/examples/invaders/simple-invaders/src/sprites.rs
@@ -1,16 +1,17 @@
 use crate::loader::Assets;
 use crate::TIME_STEP;
 use crate::{Point, HEIGHT, WIDTH};
+use alloc::vec::Vec;
 use line_drawing::Bresenham;
-use std::cmp::min;
-use std::rc::Rc;
-use std::time::Duration;
+use core::cmp::min;
+use alloc::rc::Rc;
+use core::time::Duration;
 
 // This is the type stored in the `Assets` hash map
 pub(crate) type CachedSprite = (usize, usize, Rc<[u8]>);
 
 /// Frame identifier for managing animations.
-#[derive(Debug, Eq, Hash, PartialEq)]
+#[derive(Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub(crate) enum Frame {
     Blipjoy1,
     Blipjoy2,


### PR DESCRIPTION
Aims to close https://github.com/parasyte/pixels/issues/7, by removing all dependencies on the standard library. So far I've got it compiling but all examples fail to build, so there's some work to be done (I am mainly working on the `simple-invaders` part, so I will first fix that).

Milestones:
- [x] Switch away from `NonZeroU32` (Causes some unsafety by using raw integers, I'll see what can be done), `std`-exported types such as `Vec` and `Box`.
- [x] Add optional feature to enable the standard library (Enabled by default)
- [ ] Get `invaders` example working, optionally with better performance or reduced executable size.
- [ ] Find `std::collections::HashMap` replacement ([`hashbrown` exists](https://crates.io/crates/hashbrown), as well as `BTreeMap` available on the `alloc` crate)
- [ ] Stop depending on `thiserror` (It requires `std` for some reason, or so the compiler messages say: (There's [`anyhow`](https://crates.io/crates/anyhow), it will also do the job))
```sh
error[E0433]: failed to resolve: use of undeclared crate or module `std`
   --> src/lib.rs:127:10
    |
127 | #[derive(Error, Debug)]
    |          ^^^^^ use of undeclared crate or module `std`
```

**NOTE:**
`core::error::Error`, while available and working, requires nightly. This may mean the whole pull request will be blocked until it's stabilized (Or, we could just require nightly to disable the standard library).
