### PR TITLE
Handle all wgpu::SurfaceError variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "arboard"
@@ -99,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "arrayref"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
@@ -235,7 +235,7 @@ checksum = "1aca418a974d83d40a0c1f0c5cba6ff4bc28d8df099109ca459a2118d40b6322"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -370,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "cocoa-foundation"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318"
+checksum = "931d3837c286f56e3c58423ce4eba12d08db2374461a785c86f672b08b5650d6"
 dependencies = [
  "bitflags",
  "block",
@@ -427,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "console_log"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "878ad067d4089144a36ee412d665916c665430eb84c0057b9987f424a5d15c03"
+checksum = "e89f72f65e8501878b8a004d5a1afb780987e2ce2b4532c562e367a72c57499f"
 dependencies = [
  "log",
  "web-sys",
@@ -441,6 +441,7 @@ version = "0.1.0"
 dependencies = [
  "byteorder",
  "env_logger",
+ "error-iter",
  "getrandom",
  "line_drawing",
  "log",
@@ -566,6 +567,7 @@ version = "0.1.0"
 dependencies = [
  "bytemuck",
  "env_logger",
+ "error-iter",
  "log",
  "pixels",
  "winit",
@@ -604,7 +606,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -615,7 +617,7 @@ checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -792,6 +794,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-iter"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8070547d90d1b98debb6626421d742c897942bbb78f047694a5eb769495eccd6"
+
+[[package]]
 name = "euclid"
 version = "0.22.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "fltk"
-version = "1.3.33"
+version = "1.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705cc2e45fb8e3cfbaf1dde6e7708378ec02ffcbc3361e3df5726dc7221ffaeb"
+checksum = "97d48608b0916c2950f01487bab38c81e33a1d28ebdda9896e0f8e3e095872c1"
 dependencies = [
  "bitflags",
  "crossbeam-channel",
@@ -855,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "fltk-sys"
-version = "1.3.33"
+version = "1.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bcceb27974e718b7689d55f03cb9f25c8eae34cefe99e5ef52a65e509aa611e"
+checksum = "6a22922b0fd82870e2c84c75a7e910c75dd01a262dbaa741297d0b6520977823"
 dependencies = [
  "cmake",
 ]
@@ -895,7 +903,7 @@ checksum = "c8469d0d40519bc608ec6863f1cc88f3f1deee15913f2f3b3e573d81ed38cccc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -943,24 +951,24 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -969,32 +977,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
  "futures-core",
  "futures-macro",
@@ -1223,7 +1231,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1363,7 +1371,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1500,6 +1508,7 @@ name = "imgui-winit"
 version = "0.1.0"
 dependencies = [
  "env_logger",
+ "error-iter",
  "imgui",
  "imgui-wgpu",
  "imgui-winit-support",
@@ -1547,6 +1556,7 @@ version = "0.1.0"
 dependencies = [
  "byteorder",
  "env_logger",
+ "error-iter",
  "game-loop",
  "getrandom",
  "gilrs",
@@ -1569,19 +1579,20 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
+checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
+ "hermit-abi",
  "libc",
  "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
+checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
 dependencies = [
  "hermit-abi",
  "io-lifetimes",
@@ -1607,6 +1618,22 @@ dependencies = [
  "log",
  "thiserror",
  "walkdir",
+]
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1791,6 +1818,7 @@ dependencies = [
  "egui-wgpu",
  "egui-winit",
  "env_logger",
+ "error-iter",
  "log",
  "pixels",
  "winit",
@@ -1802,6 +1830,7 @@ name = "minimal-fltk"
 version = "0.1.0"
 dependencies = [
  "env_logger",
+ "error-iter",
  "fltk",
  "log",
  "pixels",
@@ -1818,6 +1847,7 @@ name = "minimal-tao"
 version = "0.1.0"
 dependencies = [
  "env_logger",
+ "error-iter",
  "log",
  "pixels",
  "tao",
@@ -1830,6 +1860,7 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "env_logger",
+ "error-iter",
  "log",
  "pixels",
  "pollster",
@@ -1845,6 +1876,7 @@ name = "minimal-winit"
 version = "0.1.0"
 dependencies = [
  "env_logger",
+ "error-iter",
  "log",
  "pixels",
  "winit",
@@ -1957,7 +1989,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2067,7 +2099,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2285,7 +2317,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -2302,9 +2334,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
  "unicode-ident",
 ]
@@ -2317,9 +2349,9 @@ checksum = "74605f360ce573babfe43964cbe520294dcb081afbf8c108fc6e23036b4da2df"
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -2353,6 +2385,7 @@ name = "raqote-winit"
 version = "0.1.0"
 dependencies = [
  "env_logger",
+ "error-iter",
  "euclid",
  "log",
  "pixels",
@@ -2449,9 +2482,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.9"
+version = "0.36.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
+checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
 dependencies = [
  "bitflags",
  "errno",
@@ -2526,25 +2559,25 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.154"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdd151213925e7f1ab45a9bbfb129316bd00799784b174b7cc7bcd16961c49e"
+checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.154"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc80d722935453bcafdc2c9a73cd6fac4dc1938f0346035d84bf99fa9e33217"
+checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.4",
 ]
 
 [[package]]
@@ -2679,15 +2712,26 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "sw-composite"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8d4f1dd38540e3f62c393ae78e874c94491c403025368183b018e3fb098b1f"
+checksum = "9ac8fb7895b4afa060ad731a32860db8755da3449a47e796d5ecf758db2671d4"
 
 [[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c622ae390c9302e214c31013517c2061ecb2699935882c60a9b37f82f8625ae"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2731,7 +2775,7 @@ dependencies = [
  "gtk",
  "image",
  "instant",
- "jni",
+ "jni 0.20.0",
  "lazy_static",
  "libc",
  "log",
@@ -2760,7 +2804,7 @@ checksum = "3b27a4bcc5eb524658234589bdffc7e7bfb996dbae6ce9393bfd39cb4159b445"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2787,22 +2831,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.4",
 ]
 
 [[package]]
@@ -2860,6 +2904,7 @@ name = "tiny-skia-winit"
 version = "0.1.0"
 dependencies = [
  "env_logger",
+ "error-iter",
  "log",
  "pixels",
  "tiny-skia 0.8.3",
@@ -2899,9 +2944,9 @@ checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.4"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1eb0622d28f4b9c90adc4ea4b2b46b47663fde9ac5fafcb14a1369d5508825"
+checksum = "dc18466501acd8ac6a3f615dd29a3438f8ca6bb3b19537138b3106e575621274"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2951,18 +2996,18 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "ultraviolet"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf2728f3858937f50df6d92b741f53ef8fd5b5ae23b03b73fb9ac891e980df3b"
+checksum = "ca0b28b9a6ce66d47e3c5666aa738c5ec5223fcdd4c263f3edc98ab6fef618b3"
 dependencies = [
  "wide",
 ]
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524b68aca1d05e03fdf03fcdce2c6c94b6daf6d16861ddaa7e4f2b6638a9052c"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
@@ -3037,12 +3082,11 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 
@@ -3069,7 +3113,7 @@ dependencies = [
  "heck 0.3.3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3099,7 +3143,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -3168,7 +3212,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3328,13 +3372,13 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d1fa1e5c829b2bf9eb1e28fb950248b797cd6a04866fbdfa8bc31e5eef4c78"
+checksum = "579cc485bd5ce5bfa0d738e4921dd0b956eca9800be1fd2e5257ebe95bc4617e"
 dependencies = [
  "core-foundation",
  "dirs",
- "jni",
+ "jni 0.21.1",
  "log",
  "ndk-context",
  "objc",
@@ -3520,12 +3564,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04662ed0e3e5630dfa9b26e4cb823b817f1a9addda855d973a9458c236556244"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.1",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3543,7 +3587,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba01f98f509cb5dc05f4e5fc95e535f78260f15fea8fe1a8abdd08f774f1cee7"
 dependencies = [
- "syn",
+ "syn 1.0.109",
  "windows-tokens",
 ]
 
@@ -3567,12 +3611,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.1",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3586,17 +3630,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.1",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3607,9 +3651,9 @@ checksum = "f838de2fe15fe6bac988e74b798f26499a8b21a9d97edec321e79b28d1d7f597"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3625,9 +3669,9 @@ checksum = "ec7711666096bd4096ffa835238905bb33fb87267910e154b18b44eaabb340f2"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3643,9 +3687,9 @@ checksum = "763fc57100a5f7042e3057e7e8d9bdd7860d330070251a73d003563a3bb49e1b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3661,9 +3705,9 @@ checksum = "7bc7cbfe58828921e10a9f446fcaaf649204dcfe6c1ddd712c5eebae6bda1106"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3679,15 +3723,15 @@ checksum = "6868c165637d653ae1e8dc4d82c25d4f97dd6605eaa8d784b5c6e0ab2a252b65"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3703,9 +3747,9 @@ checksum = "5e4d40883ae9cae962787ca76ba76390ffa29214667a111db9e0a1ad8377e809"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winit"
@@ -3751,9 +3795,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee7b2c67f962bf5042bfd8b6a916178df33a26eec343ae064cb8e069f638fa6f"
+checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
 dependencies = [
  "memchr",
 ]

--- a/examples/conway/Cargo.toml
+++ b/examples/conway/Cargo.toml
@@ -12,6 +12,7 @@ default = ["optimize"]
 [dependencies]
 byteorder = "1"
 env_logger = "0.10"
+error-iter = "0.4"
 getrandom = "0.2"
 line_drawing = "1"
 log = "0.4"

--- a/examples/conway/src/main.rs
+++ b/examples/conway/src/main.rs
@@ -1,6 +1,7 @@
 #![deny(clippy::all)]
 #![forbid(unsafe_code)]
 
+use error_iter::ErrorIter as _;
 use log::{debug, error};
 use pixels::{Error, Pixels, SurfaceTexture};
 use winit::{
@@ -46,7 +47,7 @@ fn main() -> Result<(), Error> {
         if let Event::RedrawRequested(_) = event {
             life.draw(pixels.frame_mut());
             if let Err(err) = pixels.render() {
-                error!("pixels.render() failed: {}", err);
+                log_error("pixels.render", err);
                 *control_flow = ControlFlow::Exit;
                 return;
             }
@@ -123,7 +124,7 @@ fn main() -> Result<(), Error> {
             // Resize the window
             if let Some(size) = input.window_resized() {
                 if let Err(err) = pixels.resize_surface(size.width, size.height) {
-                    error!("pixels.resize_surface() failed: {err}");
+                    log_error("pixels.resize_surface", err);
                     *control_flow = ControlFlow::Exit;
                     return;
                 }
@@ -134,6 +135,13 @@ fn main() -> Result<(), Error> {
             window.request_redraw();
         }
     });
+}
+
+fn log_error<E: std::error::Error + 'static>(method_name: &str, err: E) {
+    error!("{method_name}() failed: {err}");
+    for source in err.sources().skip(1) {
+        error!("  Caused by: {source}");
+    }
 }
 
 /// Generate a pseudorandom seed for the game's PRNG.

--- a/examples/custom-shader/Cargo.toml
+++ b/examples/custom-shader/Cargo.toml
@@ -12,6 +12,7 @@ default = ["optimize"]
 [dependencies]
 bytemuck = "1"
 env_logger = "0.10"
+error-iter = "0.4"
 log = "0.4"
 pixels = { path = "../.." }
 winit = "0.27"

--- a/examples/custom-shader/src/main.rs
+++ b/examples/custom-shader/src/main.rs
@@ -2,6 +2,7 @@
 #![forbid(unsafe_code)]
 
 use crate::renderers::NoiseRenderer;
+use error_iter::ErrorIter as _;
 use log::error;
 use pixels::{Error, Pixels, SurfaceTexture};
 use winit::dpi::LogicalSize;
@@ -65,7 +66,7 @@ fn main() -> Result<(), Error> {
             });
 
             if let Err(err) = render_result {
-                error!("pixels.render_with() failed: {err}");
+                log_error("pixels.render_with", err);
                 *control_flow = ControlFlow::Exit;
                 return;
             }
@@ -82,12 +83,12 @@ fn main() -> Result<(), Error> {
             // Resize the window
             if let Some(size) = input.window_resized() {
                 if let Err(err) = pixels.resize_surface(size.width, size.height) {
-                    error!("pixels.resize_surface() failed: {err}");
+                    log_error("pixels.resize_surface", err);
                     *control_flow = ControlFlow::Exit;
                     return;
                 }
                 if let Err(err) = noise_renderer.resize(&pixels, size.width, size.height) {
-                    error!("noise_renderer.resize() failed: {err}");
+                    log_error("noise_renderer.resize", err);
                     *control_flow = ControlFlow::Exit;
                     return;
                 }
@@ -98,6 +99,13 @@ fn main() -> Result<(), Error> {
             window.request_redraw();
         }
     });
+}
+
+fn log_error<E: std::error::Error + 'static>(method_name: &str, err: E) {
+    error!("{method_name}() failed: {err}");
+    for source in err.sources().skip(1) {
+        error!("  Caused by: {source}");
+    }
 }
 
 impl World {

--- a/examples/imgui-winit/Cargo.toml
+++ b/examples/imgui-winit/Cargo.toml
@@ -11,6 +11,7 @@ default = ["optimize"]
 
 [dependencies]
 env_logger = "0.10"
+error-iter = "0.4"
 imgui = "0.10"
 # imgui-wgpu = "0.21"
 imgui-winit-support = "0.10"

--- a/examples/imgui-winit/src/main.rs
+++ b/examples/imgui-winit/src/main.rs
@@ -2,6 +2,7 @@
 #![forbid(unsafe_code)]
 
 use crate::gui::Gui;
+use error_iter::ErrorIter as _;
 use log::error;
 use pixels::{Error, Pixels, SurfaceTexture};
 use winit::dpi::LogicalSize;
@@ -77,7 +78,7 @@ fn main() -> Result<(), Error> {
 
             // Basic error handling
             if let Err(err) = render_result {
-                error!("pixels.render() failed: {err}");
+                log_error("pixels.render", err);
                 *control_flow = ControlFlow::Exit;
                 return;
             }
@@ -102,7 +103,7 @@ fn main() -> Result<(), Error> {
                 if size.width > 0 && size.height > 0 {
                     // Resize the surface texture
                     if let Err(err) = pixels.resize_surface(size.width, size.height) {
-                        error!("pixels.resize_surface() failed: {err}");
+                        log_error("pixels.resize_surface", err);
                         *control_flow = ControlFlow::Exit;
                         return;
                     }
@@ -111,7 +112,7 @@ fn main() -> Result<(), Error> {
                     let LogicalSize { width, height } = size.to_logical(scale_factor);
                     world.resize(width, height);
                     if let Err(err) = pixels.resize_buffer(width, height) {
-                        error!("pixels.resize_buffer() failed: {err}");
+                        log_error("pixels.resize_buffer", err);
                         *control_flow = ControlFlow::Exit;
                         return;
                     }
@@ -123,6 +124,13 @@ fn main() -> Result<(), Error> {
             window.request_redraw();
         }
     });
+}
+
+fn log_error<E: std::error::Error + 'static>(method_name: &str, err: E) {
+    error!("{method_name}() failed: {err}");
+    for source in err.sources().skip(1) {
+        error!("  Caused by: {source}");
+    }
 }
 
 impl World {

--- a/examples/invaders/Cargo.toml
+++ b/examples/invaders/Cargo.toml
@@ -12,6 +12,7 @@ default = ["optimize"]
 [dependencies]
 byteorder = "1"
 env_logger = "0.10"
+error-iter = "0.4"
 game-loop = { version = "=0.10.1", features = ["winit"] }
 getrandom = "0.2"
 gilrs = "0.10"

--- a/examples/invaders/src/main.rs
+++ b/examples/invaders/src/main.rs
@@ -1,6 +1,7 @@
 #![deny(clippy::all)]
 #![forbid(unsafe_code)]
 
+use error_iter::ErrorIter as _;
 use game_loop::{game_loop, Time, TimeTrait as _};
 use gilrs::{Button, GamepadId, Gilrs};
 use log::{debug, error};
@@ -141,7 +142,7 @@ fn main() -> Result<(), Error> {
             // Drawing
             g.game.world.draw(g.game.pixels.frame_mut());
             if let Err(err) = g.game.pixels.render() {
-                error!("pixels.render() failed: {err}");
+                log_error("pixels.render", err);
                 g.exit();
             }
 
@@ -167,13 +168,20 @@ fn main() -> Result<(), Error> {
                 // Resize the window
                 if let Some(size) = g.game.input.window_resized() {
                     if let Err(err) = g.game.pixels.resize_surface(size.width, size.height) {
-                        error!("pixels.resize_surface() failed: {err}");
+                        log_error("pixels.resize_surface", err);
                         g.exit();
                     }
                 }
             }
         },
     );
+}
+
+fn log_error<E: std::error::Error + 'static>(method_name: &str, err: E) {
+    error!("{method_name}() failed: {err}");
+    for source in err.sources().skip(1) {
+        error!("  Caused by: {source}");
+    }
 }
 
 /// Generate a pseudorandom seed for the game's PRNG.

--- a/examples/minimal-egui/Cargo.toml
+++ b/examples/minimal-egui/Cargo.toml
@@ -14,6 +14,7 @@ default = ["optimize"]
 # egui-wgpu = "0.20"
 # egui-winit = { version = "0.20", default-features = false, features = ["links"] }
 env_logger = "0.10"
+error-iter = "0.4"
 log = "0.4"
 pixels = { path = "../.." }
 winit = "0.27"

--- a/examples/minimal-egui/src/main.rs
+++ b/examples/minimal-egui/src/main.rs
@@ -2,6 +2,7 @@
 #![forbid(unsafe_code)]
 
 use crate::gui::Framework;
+use error_iter::ErrorIter as _;
 use log::error;
 use pixels::{Error, Pixels, SurfaceTexture};
 use winit::dpi::LogicalSize;
@@ -72,7 +73,7 @@ fn main() -> Result<(), Error> {
             // Resize the window
             if let Some(size) = input.window_resized() {
                 if let Err(err) = pixels.resize_surface(size.width, size.height) {
-                    error!("pixels.resize_surface() failed: {err}");
+                    log_error("pixels.resize_surface", err);
                     *control_flow = ControlFlow::Exit;
                     return;
                 }
@@ -110,13 +111,20 @@ fn main() -> Result<(), Error> {
 
                 // Basic error handling
                 if let Err(err) = render_result {
-                    error!("pixels.render() failed: {err}");
+                    log_error("pixels.render", err);
                     *control_flow = ControlFlow::Exit;
                 }
             }
             _ => (),
         }
     });
+}
+
+fn log_error<E: std::error::Error + 'static>(method_name: &str, err: E) {
+    error!("{method_name}() failed: {err}");
+    for source in err.sources().skip(1) {
+        error!("  Caused by: {source}");
+    }
 }
 
 impl World {

--- a/examples/minimal-fltk/Cargo.toml
+++ b/examples/minimal-fltk/Cargo.toml
@@ -10,6 +10,7 @@ optimize = ["log/release_max_level_warn"]
 default = ["optimize"]
 
 [dependencies]
+error-iter = "0.4"
 fltk = { version = "1", features = ["rwh05", "no-images", "no-pango"] }
 env_logger = "0.10"
 log = "0.4"

--- a/examples/minimal-tao/Cargo.toml
+++ b/examples/minimal-tao/Cargo.toml
@@ -11,6 +11,7 @@ default = ["optimize"]
 
 [dependencies]
 env_logger = "0.10"
+error-iter = "0.4"
 log = "0.4"
 pixels = { path = "../.." }
 tao = "0.17"

--- a/examples/minimal-web/Cargo.toml
+++ b/examples/minimal-web/Cargo.toml
@@ -10,6 +10,7 @@ optimize = ["log/release_max_level_warn"]
 default = ["optimize"]
 
 [dependencies]
+error-iter = "0.4"
 log = "0.4"
 pixels = { path = "../.." }
 winit = "0.27"

--- a/examples/minimal-winit/Cargo.toml
+++ b/examples/minimal-winit/Cargo.toml
@@ -11,6 +11,7 @@ default = ["optimize"]
 
 [dependencies]
 env_logger = "0.10"
+error-iter = "0.4"
 log = "0.4"
 pixels = { path = "../.." }
 winit = "0.27"

--- a/examples/raqote-winit/Cargo.toml
+++ b/examples/raqote-winit/Cargo.toml
@@ -11,6 +11,7 @@ default = ["optimize"]
 
 [dependencies]
 env_logger = "0.10"
+error-iter = "0.4"
 euclid = "0.22"
 log = "0.4"
 pixels = { path = "../.." }

--- a/examples/raqote-winit/src/main.rs
+++ b/examples/raqote-winit/src/main.rs
@@ -2,6 +2,7 @@
 #![forbid(unsafe_code)]
 
 use crate::shapes::Shapes;
+use error_iter::ErrorIter as _;
 use log::error;
 use pixels::{Error, Pixels, SurfaceTexture};
 use std::time::Instant;
@@ -57,7 +58,7 @@ fn main() -> Result<(), Error> {
             }
 
             if let Err(err) = pixels.render() {
-                error!("pixels.render() failed: {err}");
+                log_error("pixels.render", err);
                 *control_flow = ControlFlow::Exit;
                 return;
             }
@@ -74,7 +75,7 @@ fn main() -> Result<(), Error> {
             // Resize the window
             if let Some(size) = input.window_resized() {
                 if let Err(err) = pixels.resize_surface(size.width, size.height) {
-                    error!("pixels.resize_surface() failed: {err}");
+                    log_error("pixels.resize_surface", err);
                     *control_flow = ControlFlow::Exit;
                     return;
                 }
@@ -87,4 +88,11 @@ fn main() -> Result<(), Error> {
             now = Instant::now();
         }
     });
+}
+
+fn log_error<E: std::error::Error + 'static>(method_name: &str, err: E) {
+    error!("{method_name}() failed: {err}");
+    for source in err.sources().skip(1) {
+        error!("  Caused by: {source}");
+    }
 }

--- a/examples/tiny-skia-winit/Cargo.toml
+++ b/examples/tiny-skia-winit/Cargo.toml
@@ -11,6 +11,7 @@ default = ["optimize"]
 
 [dependencies]
 env_logger = "0.10"
+error-iter = "0.4"
 log = "0.4"
 pixels = { path = "../.." }
 winit = "0.27"

--- a/examples/tiny-skia-winit/src/main.rs
+++ b/examples/tiny-skia-winit/src/main.rs
@@ -1,6 +1,7 @@
 #![deny(clippy::all)]
 #![forbid(unsafe_code)]
 
+use error_iter::ErrorIter as _;
 use log::error;
 use pixels::{Error, Pixels, SurfaceTexture};
 use std::time::Instant;
@@ -45,7 +46,7 @@ fn main() -> Result<(), Error> {
         if let Event::RedrawRequested(_) = event {
             pixels.frame_mut().copy_from_slice(drawing.data());
             if let Err(err) = pixels.render() {
-                error!("pixels.render() failed: {err}");
+                log_error("pixels.render", err);
                 *control_flow = ControlFlow::Exit;
                 return;
             }
@@ -62,7 +63,7 @@ fn main() -> Result<(), Error> {
             // Resize the window
             if let Some(size) = input.window_resized() {
                 if let Err(err) = pixels.resize_surface(size.width, size.height) {
-                    error!("pixels.resize_surface() failed: {err}");
+                    log_error("pixels.resize_surface", err);
                     *control_flow = ControlFlow::Exit;
                     return;
                 }
@@ -73,4 +74,11 @@ fn main() -> Result<(), Error> {
             window.request_redraw();
         }
     });
+}
+
+fn log_error<E: std::error::Error + 'static>(method_name: &str, err: E) {
+    error!("{method_name}() failed: {err}");
+    for source in err.sources().skip(1) {
+        error!("  Caused by: {source}");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -467,19 +467,14 @@ impl Pixels {
             &PixelsContext,
         ) -> Result<(), DynError>,
     {
-        let frame = self
-            .context
-            .surface
-            .get_current_texture()
-            .or_else(|err| match err {
-                wgpu::SurfaceError::Outdated => {
-                    // Reconfigure the surface to mitigate race condition on window resize.
-                    // See https://github.com/parasyte/pixels/issues/121
-                    self.reconfigure_surface();
-                    self.context.surface.get_current_texture()
-                }
-                err => Err(err),
-            })?;
+        let frame = self.context.surface.get_current_texture().or_else(|_| {
+            // Reconfigure the surface to mitigate race condition on window resize.
+            // See https://github.com/parasyte/pixels/issues/121
+            // And to prevent random failures.
+            // See https://github.com/parasyte/pixels/issues/346
+            self.reconfigure_surface();
+            self.context.surface.get_current_texture()
+        })?;
         let mut encoder =
             self.context
                 .device

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -468,9 +468,8 @@ impl Pixels {
         ) -> Result<(), DynError>,
     {
         let frame = self.context.surface.get_current_texture().or_else(|_| {
-            // Reconfigure the surface to mitigate race condition on window resize.
+            // Reconfigure the surface and retry immediately on any error.
             // See https://github.com/parasyte/pixels/issues/121
-            // And to prevent random failures.
             // See https://github.com/parasyte/pixels/issues/346
             self.reconfigure_surface();
             self.context.surface.get_current_texture()


### PR DESCRIPTION
This fixes error handling for all `wgpu::SurfaceError` variants. It also adds more context to error messages printed by the examples.

Closes #346