### PR TITLE
Enable all wgpu backends

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -53,17 +53,7 @@ impl<'req, 'dev, 'win, W: HasRawWindowHandle + HasRawDisplayHandle>
         Self {
             request_adapter_options: None,
             device_descriptor: None,
-            backend: wgpu::util::backend_bits_from_env().unwrap_or({
-                #[cfg(not(target_arch = "wasm32"))]
-                {
-                    wgpu::Backends::PRIMARY
-                }
-
-                #[cfg(target_arch = "wasm32")]
-                {
-                    wgpu::Backends::all()
-                }
-            }),
+            backend: wgpu::util::backend_bits_from_env().unwrap_or_else(wgpu::Backends::all),
             width,
             height,
             _pixel_aspect_ratio: 1.0,
@@ -94,7 +84,7 @@ impl<'req, 'dev, 'win, W: HasRawWindowHandle + HasRawDisplayHandle>
 
     /// Set which backends wgpu will attempt to use.
     ///
-    /// The default value is `PRIMARY`, which enables the well supported backends for wgpu.
+    /// The default enables all backends, including the backends with "best effort" support in wgpu.
     pub fn wgpu_backend(mut self, backend: wgpu::Backends) -> Self {
         self.backend = backend;
         self


### PR DESCRIPTION
- This will allow `pixels` to run on platforms that have OpenGL without any extra configuration.
- It is better to allow wgpu to fallback to OpenGL than to select a Vulkan software rasterizer. This is the case on WSL2, where the only hardware-based adapter is available with the GLES backend.
- Fixes #354