### PR TITLE
Add present mode setters on Pixels

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,6 +382,31 @@ impl Pixels {
         Ok(())
     }
 
+    /// Enable or disable Vsync.
+    ///
+    /// Vsync is enabled by default. It cannot be disabled on Web targets.
+    ///
+    /// The `wgpu` present mode will be set to `AutoVsync` when Vsync is enabled, or `AutoNoVsync`
+    /// when Vsync is disabled. To set the present mode to `Mailbox` or another value, use the
+    /// [`Pixels::set_present_mode`] method.
+    pub fn enable_vsync(&mut self, enable_vsync: bool) {
+        self.present_mode = if enable_vsync {
+            wgpu::PresentMode::AutoVsync
+        } else {
+            wgpu::PresentMode::AutoNoVsync
+        };
+        self.reconfigure_surface();
+    }
+
+    /// Set the `wgpu` present mode.
+    ///
+    /// This differs from [`Pixels::enable_vsync`] by allowing the present mode to be set to
+    /// any value.
+    pub fn set_present_mode(&mut self, present_mode: wgpu::PresentMode) {
+        self.present_mode = present_mode;
+        self.reconfigure_surface();
+    }
+
     /// Draw this pixel buffer to the configured [`SurfaceTexture`].
     ///
     /// # Errors

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,6 +398,14 @@ impl Pixels {
         self.reconfigure_surface();
     }
 
+    /// Get the `wgpu` present mode.
+    ///
+    /// Returns the present mode currently in use by the surface, which can be changed through
+    /// [`Pixels::enable_vsync`] or [`Pixels::set_present_mode`].
+    pub fn present_mode(&self) -> wgpu::PresentMode {
+        self.present_mode
+    }
+
     /// Set the `wgpu` present mode.
     ///
     /// This differs from [`Pixels::enable_vsync`] by allowing the present mode to be set to


### PR DESCRIPTION
Closes #372.

Add `set_present_mode` and `enable_vsync` methods on `Pixels`. The documentation is almost identical to the corresponding methods on `PixelsBuilder` since they do the same thing but after the instance has been created.