### PR TITLE
Update `winit` to 0.28.7 in most examples (except `imgui-winit`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,7 +497,7 @@ dependencies = [
  "log",
  "pixels",
  "randomize",
- "winit 0.28.6",
+ "winit 0.28.7",
  "winit_input_helper 0.14.1",
 ]
 
@@ -620,7 +620,7 @@ dependencies = [
  "error-iter",
  "log",
  "pixels",
- "winit 0.28.6",
+ "winit 0.28.7",
  "winit_input_helper 0.14.1",
 ]
 
@@ -757,7 +757,7 @@ dependencies = [
  "log",
  "raw-window-handle 0.5.2",
  "webbrowser",
- "winit 0.28.6",
+ "winit 0.28.7",
 ]
 
 [[package]]
@@ -1056,7 +1056,7 @@ checksum = "d96fac7dbca77aeb9f72968756770bdba2063a016166fa130d99232a8988bc36"
 dependencies = [
  "wasm-bindgen",
  "web-sys",
- "winit 0.28.6",
+ "winit 0.28.7",
 ]
 
 [[package]]
@@ -1603,7 +1603,7 @@ dependencies = [
  "log",
  "pixels",
  "simple-invaders",
- "winit 0.28.6",
+ "winit 0.28.7",
  "winit_input_helper 0.14.1",
 ]
 
@@ -1877,7 +1877,7 @@ dependencies = [
  "error-iter",
  "log",
  "pixels",
- "winit 0.28.6",
+ "winit 0.28.7",
  "winit_input_helper 0.14.1",
 ]
 
@@ -1923,7 +1923,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winit 0.28.6",
+ "winit 0.28.7",
  "winit_input_helper 0.14.1",
 ]
 
@@ -1935,7 +1935,7 @@ dependencies = [
  "error-iter",
  "log",
  "pixels",
- "winit 0.28.6",
+ "winit 0.28.7",
  "winit_input_helper 0.14.1",
 ]
 
@@ -1947,7 +1947,7 @@ dependencies = [
  "env_logger",
  "log",
  "pixels",
- "winit 0.28.6",
+ "winit 0.28.7",
 ]
 
 [[package]]
@@ -2346,7 +2346,7 @@ dependencies = [
  "thiserror",
  "ultraviolet",
  "wgpu",
- "winit 0.28.6",
+ "winit 0.28.7",
 ]
 
 [[package]]
@@ -2473,7 +2473,7 @@ dependencies = [
  "log",
  "pixels",
  "raqote",
- "winit 0.28.6",
+ "winit 0.28.7",
  "winit_input_helper 0.14.1",
 ]
 
@@ -3026,7 +3026,7 @@ dependencies = [
  "log",
  "pixels",
  "tiny-skia 0.11.0",
- "winit 0.28.6",
+ "winit 0.28.7",
  "winit_input_helper 0.14.1",
 ]
 
@@ -3874,9 +3874,9 @@ dependencies = [
 
 [[package]]
 name = "winit"
-version = "0.28.6"
+version = "0.28.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "866db3f712fffba75d31bf0cdecf357c8aeafd158c5b7ab51dba2a2b2d47f196"
+checksum = "9596d90b45384f5281384ab204224876e8e8bf7d58366d9b795ad99aa9894b94"
 dependencies = [
  "android-activity",
  "bitflags 1.3.2",
@@ -3922,7 +3922,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de0485e86aa2ee87d2d4c373a908c9548357bc65c5bce19fd884c8ea9eac4d7"
 dependencies = [
- "winit 0.28.6",
+ "winit 0.28.7",
 ]
 
 [[package]]

--- a/examples/conway/Cargo.toml
+++ b/examples/conway/Cargo.toml
@@ -18,5 +18,5 @@ line_drawing = "1"
 log = "0.4"
 pixels = { path = "../.." }
 randomize = "3"
-winit = "0.28"
+winit = "0.28.7"
 winit_input_helper = "0.14"

--- a/examples/custom-shader/Cargo.toml
+++ b/examples/custom-shader/Cargo.toml
@@ -15,5 +15,5 @@ env_logger = "0.10"
 error-iter = "0.4"
 log = "0.4"
 pixels = { path = "../.." }
-winit = "0.28"
+winit = "0.28.7"
 winit_input_helper = "0.14"

--- a/examples/invaders/Cargo.toml
+++ b/examples/invaders/Cargo.toml
@@ -19,5 +19,5 @@ gilrs = "0.10"
 log = "0.4"
 pixels = { path = "../.." }
 simple-invaders = { path = "simple-invaders" }
-winit = "0.28"
+winit = "0.28.7"
 winit_input_helper = "0.14"

--- a/examples/minimal-egui/Cargo.toml
+++ b/examples/minimal-egui/Cargo.toml
@@ -17,5 +17,5 @@ env_logger = "0.10"
 error-iter = "0.4"
 log = "0.4"
 pixels = { path = "../.." }
-winit = "0.28"
+winit = "0.28.7"
 winit_input_helper = "0.14"

--- a/examples/minimal-web/Cargo.toml
+++ b/examples/minimal-web/Cargo.toml
@@ -13,7 +13,7 @@ default = ["optimize"]
 error-iter = "0.4"
 log = "0.4"
 pixels = { path = "../.." }
-winit = "0.28"
+winit = "0.28.7"
 winit_input_helper = "0.14"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/examples/minimal-winit/Cargo.toml
+++ b/examples/minimal-winit/Cargo.toml
@@ -14,5 +14,5 @@ env_logger = "0.10"
 error-iter = "0.4"
 log = "0.4"
 pixels = { path = "../.." }
-winit = "0.28"
+winit = "0.28.7"
 winit_input_helper = "0.14"

--- a/examples/raqote-winit/Cargo.toml
+++ b/examples/raqote-winit/Cargo.toml
@@ -16,5 +16,5 @@ euclid = "0.22"
 log = "0.4"
 pixels = { path = "../.." }
 raqote = { version = "0.8", default-features = false }
-winit = "0.28"
+winit = "0.28.7"
 winit_input_helper = "0.14"

--- a/examples/tiny-skia-winit/Cargo.toml
+++ b/examples/tiny-skia-winit/Cargo.toml
@@ -15,5 +15,5 @@ error-iter = "0.4"
 log = "0.4"
 pixels = { path = "../.." }
 tiny-skia = "0.11"
-winit = "0.28"
+winit = "0.28.7"
 winit_input_helper = "0.14"


### PR DESCRIPTION
Updated most examples (related to https://github.com/rust-windowing/winit/issues/2876). The `imgui-winit` wasn't updated because it relies on `imgui-winit-support` which hasn't been updated in a while (see https://github.com/imgui-rs/imgui-rs/issues/749)