### PR TITLE
Replace `line_drawing` with `clipline`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,6 +394,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75476fe966a8af7c0ceae2a3e514afa87d4451741fcdfab8bfaa07ad301842ec"
 
 [[package]]
+name = "clipline"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261dc8d360e39175d787ffc8ee5885da0ec7fe167171d574f6857772a348c344"
+
+[[package]]
 name = "cmake"
 version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,10 +496,10 @@ name = "conway"
 version = "0.1.0"
 dependencies = [
  "byteorder",
+ "clipline",
  "env_logger",
  "error-iter",
  "getrandom",
- "line_drawing",
  "log",
  "pixels",
  "randomize",
@@ -1760,15 +1766,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "line_drawing"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1478a313008a3e6c8149995e90a99ee9094034b5c5c3da1eeb81183cb61d1d"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2717,8 +2714,8 @@ name = "simple-invaders"
 version = "0.1.0"
 dependencies = [
  "byteorder",
+ "clipline",
  "getrandom",
- "line_drawing",
  "pcx",
  "randomize",
 ]

--- a/examples/conway/Cargo.toml
+++ b/examples/conway/Cargo.toml
@@ -14,7 +14,7 @@ byteorder = "1"
 env_logger = "0.10"
 error-iter = "0.4"
 getrandom = "0.2"
-line_drawing = "1"
+clipline = "0.1.0"
 log = "0.4"
 pixels = { path = "../.." }
 randomize = "3"

--- a/examples/conway/Cargo.toml
+++ b/examples/conway/Cargo.toml
@@ -14,7 +14,7 @@ byteorder = "1"
 env_logger = "0.10"
 error-iter = "0.4"
 getrandom = "0.2"
-clipline = "0.1.0"
+clipline = "0.1.1"
 log = "0.4"
 pixels = { path = "../.." }
 randomize = "3"

--- a/examples/conway/src/main.rs
+++ b/examples/conway/src/main.rs
@@ -318,15 +318,16 @@ impl ConwayGrid {
         }
     }
 
-    fn set_line(&mut self, x0: isize, y0: isize, x1: isize, y1: isize, alive: bool) {
-        clipline::clipline(
+    fn set_line(&mut self, x0: isize, y0: isize, x1: isize, y1: isize, alive: bool) -> Option<()> {
+        // possible to optimize by matching on Clipline and iterating over its arms
+        for (x, y) in clipline::Clipline::new(
             ((x0, y0), (x1, y1)),
             ((0, 0), (self.width as isize - 1, self.height as isize - 1)),
-            |x, y| {
-                let (x, y) = (x as usize, y as usize);
-                self.cells[x + y * self.width].set_alive(alive);
-            },
-        );
+        )? {
+            let (x, y) = (x as usize, y as usize);
+            self.cells[x + y * self.width].set_alive(alive);
+        }
+        Some(())
     }
 
     fn grid_idx<I: std::convert::TryInto<usize>>(&self, x: I, y: I) -> Option<usize> {

--- a/examples/conway/src/main.rs
+++ b/examples/conway/src/main.rs
@@ -319,18 +319,14 @@ impl ConwayGrid {
     }
 
     fn set_line(&mut self, x0: isize, y0: isize, x1: isize, y1: isize, alive: bool) {
-        // probably should do sutherland-hodgeman if this were more serious.
-        // instead just clamp the start pos, and draw until moving towards the
-        // end pos takes us out of bounds.
-        let x0 = x0.clamp(0, self.width as isize);
-        let y0 = y0.clamp(0, self.height as isize);
-        for (x, y) in line_drawing::Bresenham::new((x0, y0), (x1, y1)) {
-            if let Some(i) = self.grid_idx(x, y) {
-                self.cells[i].set_alive(alive);
-            } else {
-                break;
-            }
-        }
+        clipline::clipline(
+            ((x0, y0), (x1, y1)),
+            ((0, 0), (self.width as isize - 1, self.height as isize - 1)),
+            |x, y| {
+                let (x, y) = (x as usize, y as usize);
+                self.cells[x + y * self.width].set_alive(alive);
+            },
+        );
     }
 
     fn grid_idx<I: std::convert::TryInto<usize>>(&self, x: I, y: I) -> Option<usize> {

--- a/examples/invaders/simple-invaders/Cargo.toml
+++ b/examples/invaders/simple-invaders/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Jay Oster <jay@kodewerx.org>"]
 edition = "2018"
 
 [dependencies]
-clipline = "0.1.0"
+clipline = "0.1.1"
 pcx = "0.2"
 randomize = "3.0"
 

--- a/examples/invaders/simple-invaders/Cargo.toml
+++ b/examples/invaders/simple-invaders/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Jay Oster <jay@kodewerx.org>"]
 edition = "2018"
 
 [dependencies]
-line_drawing = "1.0"
+clipline = "0.1.0"
 pcx = "0.2"
 randomize = "3.0"
 

--- a/examples/invaders/simple-invaders/src/sprites.rs
+++ b/examples/invaders/simple-invaders/src/sprites.rs
@@ -213,17 +213,17 @@ where
 }
 
 /// Draw a line to the pixel buffer using Bresenham's algorithm.
-pub(crate) fn line(screen: &mut [u8], p1: &Point, p2: &Point, color: [u8; 4]) {
+pub(crate) fn line(screen: &mut [u8], p1: &Point, p2: &Point, color: [u8; 4]) -> Option<()> {
     let p1 = (p1.x as isize, p1.y as isize);
     let p2 = (p2.x as isize, p2.y as isize);
     let clip_max = (WIDTH as isize - 1, HEIGHT as isize - 1);
-
-    clipline::clipline((p1, p2), ((0, 0), clip_max), |x, y| {
+    for (x, y) in clipline::Clipline::new((p1, p2), ((0, 0), clip_max))? {
         let (x, y) = (x as usize, y as usize);
         let i = x * 4 + y * WIDTH * 4;
 
         screen[i..i + 4].copy_from_slice(&color);
-    });
+    }
+    Some(())
 }
 
 /// Draw a rectangle to the pixel buffer using two points in opposite corners.

--- a/examples/invaders/simple-invaders/src/sprites.rs
+++ b/examples/invaders/simple-invaders/src/sprites.rs
@@ -3,9 +3,7 @@ use crate::TIME_STEP;
 use crate::{Point, HEIGHT, WIDTH};
 use alloc::rc::Rc;
 use alloc::vec::Vec;
-use core::cmp::min;
 use core::time::Duration;
-use line_drawing::Bresenham;
 
 // This is the type stored in the `Assets` hash map
 pub(crate) type CachedSprite = (usize, usize, Rc<[u8]>);
@@ -216,16 +214,16 @@ where
 
 /// Draw a line to the pixel buffer using Bresenham's algorithm.
 pub(crate) fn line(screen: &mut [u8], p1: &Point, p2: &Point, color: [u8; 4]) {
-    let p1 = (p1.x as i64, p1.y as i64);
-    let p2 = (p2.x as i64, p2.y as i64);
+    let p1 = (p1.x as isize, p1.y as isize);
+    let p2 = (p2.x as isize, p2.y as isize);
+    let clip_max = (WIDTH as isize - 1, HEIGHT as isize - 1);
 
-    for (x, y) in Bresenham::new(p1, p2) {
-        let x = min(x as usize, WIDTH - 1);
-        let y = min(y as usize, HEIGHT - 1);
+    clipline::clipline((p1, p2), ((0, 0), clip_max), |x, y| {
+        let (x, y) = (x as usize, y as usize);
         let i = x * 4 + y * WIDTH * 4;
 
         screen[i..i + 4].copy_from_slice(&color);
-    }
+    });
 }
 
 /// Draw a rectangle to the pixel buffer using two points in opposite corners.


### PR DESCRIPTION
Replaced `line_drawing` with my [`clipline`](https://github.com/nxsaken/clipline) crate which implements a variation of Bresenham's algorithm with built-in pixel-perfect clipping.