### PR TITLE
PR: Migrate minimal winit example from winit 0.29 → winit 0.30

### DIFF
--- a/examples/minimal-winit/Cargo.toml
+++ b/examples/minimal-winit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "minimal-winit"
 version = "0.1.0"
 authors = ["Jay Oster <jay@kodewerx.org>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [features]
@@ -10,9 +10,8 @@ optimize = ["log/release_max_level_warn"]
 default = ["optimize"]
 
 [dependencies]
-env_logger = "0.10"
-error-iter = "0.4"
 log = "0.4"
+env_logger = "0.11"
+error-iter = "0.4"
 pixels = { path = "../.." }
-winit = "0.29"
-winit_input_helper = "0.15"
+winit = "0.30

--- a/examples/minimal-winit/src/main.rs
+++ b/examples/minimal-winit/src/main.rs
@@ -4,18 +4,17 @@
 use error_iter::ErrorIter as _;
 use log::error;
 use pixels::{Error, Pixels, SurfaceTexture};
+use winit::application::ApplicationHandler;
 use winit::dpi::LogicalSize;
-use winit::event::{Event, WindowEvent};
-use winit::event_loop::EventLoop;
-use winit::keyboard::KeyCode;
-use winit::window::WindowBuilder;
-use winit_input_helper::WinitInputHelper;
+use winit::event::{ElementState, KeyEvent, WindowEvent};
+use winit::event_loop::{ActiveEventLoop, EventLoop};
+use winit::keyboard::{KeyCode, PhysicalKey};
+use winit::window::{Window, WindowAttributes};
 
 const WIDTH: u32 = 320;
 const HEIGHT: u32 = 240;
 const BOX_SIZE: i16 = 64;
 
-/// Representation of the application state. In this example, a box will bounce around the screen.
 struct World {
     box_x: i16,
     box_y: i16,
@@ -23,65 +22,32 @@ struct World {
     velocity_y: i16,
 }
 
-fn main() -> Result<(), Error> {
-    env_logger::init();
-    let event_loop = EventLoop::new().unwrap();
-    let mut input = WinitInputHelper::new();
-    let window = {
-        let size = LogicalSize::new(WIDTH as f64, HEIGHT as f64);
-        WindowBuilder::new()
-            .with_title("Hello Pixels")
-            .with_inner_size(size)
-            .with_min_inner_size(size)
-            .build(&event_loop)
-            .unwrap()
-    };
-
-    let mut pixels = {
-        let window_size = window.inner_size();
-        let surface_texture = SurfaceTexture::new(window_size.width, window_size.height, &window);
-        Pixels::new(WIDTH, HEIGHT, surface_texture)?
-    };
-    let mut world = World::new();
-
-    let res = event_loop.run(|event, elwt| {
-        // Draw the current frame
-        if let Event::WindowEvent {
-            event: WindowEvent::RedrawRequested,
-            ..
-        } = event
-        {
-            world.draw(pixels.frame_mut());
-            if let Err(err) = pixels.render() {
-                log_error("pixels.render", err);
-                elwt.exit();
-                return;
-            }
+impl World {
+    fn new() -> Self {
+        Self { box_x: 24, box_y: 16, velocity_x: 1, velocity_y: 1 }
+    }
+    fn update(&mut self) {
+        if self.box_x <= 0 || self.box_x + BOX_SIZE > WIDTH as i16 {
+            self.velocity_x *= -1;
         }
-
-        // Handle input events
-        if input.update(&event) {
-            // Close events
-            if input.key_pressed(KeyCode::Escape) || input.close_requested() {
-                elwt.exit();
-                return;
-            }
-
-            // Resize the window
-            if let Some(size) = input.window_resized() {
-                if let Err(err) = pixels.resize_surface(size.width, size.height) {
-                    log_error("pixels.resize_surface", err);
-                    elwt.exit();
-                    return;
-                }
-            }
-
-            // Update internal state and request a redraw
-            world.update();
-            window.request_redraw();
+        if self.box_y <= 0 || self.box_y + BOX_SIZE > HEIGHT as i16 {
+            self.velocity_y *= -1;
         }
-    });
-    res.map_err(|e| Error::UserDefined(Box::new(e)))
+        self.box_x += self.velocity_x;
+        self.box_y += self.velocity_y;
+    }
+    fn draw(&self, frame: &mut [u8]) {
+        for (i, px) in frame.chunks_exact_mut(4).enumerate() {
+            let x = (i % WIDTH as usize) as i16;
+            let y = (i / WIDTH as usize) as i16;
+            let inside = x >= self.box_x
+                && x < self.box_x + BOX_SIZE
+                && y >= self.box_y
+                && y < self.box_y + BOX_SIZE;
+            let rgba = if inside { [0x5e, 0x48, 0xe8, 0xff] } else { [0x48, 0xb2, 0xe8, 0xff] };
+            px.copy_from_slice(&rgba);
+        }
+    }
 }
 
 fn log_error<E: std::error::Error + 'static>(method_name: &str, err: E) {
@@ -91,50 +57,94 @@ fn log_error<E: std::error::Error + 'static>(method_name: &str, err: E) {
     }
 }
 
-impl World {
-    /// Create a new `World` instance that can draw a moving box.
+struct App {
+    window: Option<&'static Window>,     // leaked &'static Window
+    pixels: Option<Pixels<'static>>,     // borrows the window
+    world: World,
+}
+
+impl App {
     fn new() -> Self {
-        Self {
-            box_x: 24,
-            box_y: 16,
-            velocity_x: 1,
-            velocity_y: 1,
+        Self { window: None, pixels: None, world: World::new() }
+    }
+}
+
+impl ApplicationHandler for App {
+    fn resumed(&mut self, elwt: &ActiveEventLoop) {
+        if self.window.is_none() {
+            // Create window
+            let size = LogicalSize::new(WIDTH as f64, HEIGHT as f64);
+            let attrs = WindowAttributes::default()
+                .with_title("Hello Pixels")
+                .with_inner_size(size)
+                .with_min_inner_size(size);
+            let window = elwt.create_window(attrs).expect("create window");
+
+            // Leak to get &'static Window so Pixels can live in the struct
+            let window: &'static Window = Box::leak(Box::new(window));
+            let win_size = window.inner_size();
+
+            // Create Pixels
+            let surface = SurfaceTexture::new(win_size.width, win_size.height, window);
+            let pixels = Pixels::new(WIDTH, HEIGHT, surface).expect("create pixels");
+
+            self.window = Some(window);
+            self.pixels = Some(pixels);
         }
     }
 
-    /// Update the `World` internal state; bounce the box around the screen.
-    fn update(&mut self) {
-        if self.box_x <= 0 || self.box_x + BOX_SIZE > WIDTH as i16 {
-            self.velocity_x *= -1;
-        }
-        if self.box_y <= 0 || self.box_y + BOX_SIZE > HEIGHT as i16 {
-            self.velocity_y *= -1;
-        }
+    fn window_event(
+        &mut self,
+        elwt: &ActiveEventLoop,
+        window_id: winit::window::WindowId,
+        event: WindowEvent,
+    ) {
+        let Some(window) = self.window else { return };
+        if window_id != window.id() { return; }
 
-        self.box_x += self.velocity_x;
-        self.box_y += self.velocity_y;
+        match event {
+            WindowEvent::CloseRequested => elwt.exit(),
+            WindowEvent::KeyboardInput {
+                event: KeyEvent {
+                    physical_key: PhysicalKey::Code(KeyCode::Escape),
+                    state: ElementState::Pressed,
+                    ..
+                },
+                ..
+            } => elwt.exit(),
+            WindowEvent::Resized(size) => {
+                if let Some(pixels) = self.pixels.as_mut() {
+                    if let Err(err) = pixels.resize_surface(size.width, size.height) {
+                        log_error("pixels.resize_surface", err);
+                        elwt.exit();
+                    }
+                }
+            }
+            WindowEvent::RedrawRequested => {
+                if let Some(pixels) = self.pixels.as_mut() {
+                    self.world.draw(pixels.frame_mut());
+                    if let Err(err) = pixels.render() {
+                        log_error("pixels.render", err);
+                        elwt.exit();
+                    }
+                }
+            }
+            _ => {}
+        }
     }
 
-    /// Draw the `World` state to the frame buffer.
-    ///
-    /// Assumes the default texture format: `wgpu::TextureFormat::Rgba8UnormSrgb`
-    fn draw(&self, frame: &mut [u8]) {
-        for (i, pixel) in frame.chunks_exact_mut(4).enumerate() {
-            let x = (i % WIDTH as usize) as i16;
-            let y = (i / WIDTH as usize) as i16;
-
-            let inside_the_box = x >= self.box_x
-                && x < self.box_x + BOX_SIZE
-                && y >= self.box_y
-                && y < self.box_y + BOX_SIZE;
-
-            let rgba = if inside_the_box {
-                [0x5e, 0x48, 0xe8, 0xff]
-            } else {
-                [0x48, 0xb2, 0xe8, 0xff]
-            };
-
-            pixel.copy_from_slice(&rgba);
+    fn about_to_wait(&mut self, _elwt: &ActiveEventLoop) {
+        if let Some(window) = self.window {
+            self.world.update();
+            window.request_redraw();
         }
     }
+}
+
+fn main() -> Result<(), Error> {
+    env_logger::init();
+    let event_loop = EventLoop::new().expect("create event loop");
+    let mut app = App::new();
+    let res = event_loop.run_app(&mut app);
+    res.map_err(|e| Error::UserDefined(Box::new(e)))
 }


### PR DESCRIPTION
## Summary
Migrates the minimal example from **winit 0.29 + pixels 0.13** → **winit 0.30 + pixels 0.15**.  
Uses the new `ApplicationHandler` API (`run_app`, `resumed`, `window_event`, `about_to_wait`).

## Key changes
- Replaced `EventLoop::run` with `run_app`.
- Window creation now happens in `resumed`.
- Drawing handled in `WindowEvent::RedrawRequested`; redraw scheduled in `about_to_wait`.
- Removed `winit_input_helper` for simplicity.
- Used a simple `Box::leak` to satisfy the `Pixels<'_>` lifetime.

## Cargo.toml

```toml
[dependencies]
log = "0.4"
env_logger = "0.11"
error-iter = "0.4"
pixels = "0.15"
winit = "0.30"
```

## Example main.rs

```rust
#![deny(clippy::all)]
#![forbid(unsafe_code)]

use error_iter::ErrorIter as _;
use log::error;
use pixels::{Error, Pixels, SurfaceTexture};
use winit::application::ApplicationHandler;
use winit::dpi::LogicalSize;
use winit::event::{ElementState, KeyEvent, WindowEvent};
use winit::event_loop::{ActiveEventLoop, EventLoop};
use winit::keyboard::{KeyCode, PhysicalKey};
use winit::window::{Window, WindowAttributes};

const WIDTH: u32 = 320;
const HEIGHT: u32 = 240;
const BOX_SIZE: i16 = 64;

struct World {
    box_x: i16,
    box_y: i16,
    velocity_x: i16,
    velocity_y: i16,
}

impl World {
    fn new() -> Self {
        Self { box_x: 24, box_y: 16, velocity_x: 1, velocity_y: 1 }
    }
    fn update(&mut self) {
        if self.box_x <= 0 || self.box_x + BOX_SIZE > WIDTH as i16 {
            self.velocity_x *= -1;
        }
        if self.box_y <= 0 || self.box_y + BOX_SIZE > HEIGHT as i16 {
            self.velocity_y *= -1;
        }
        self.box_x += self.velocity_x;
        self.box_y += self.velocity_y;
    }
    fn draw(&self, frame: &mut [u8]) {
        for (i, px) in frame.chunks_exact_mut(4).enumerate() {
            let x = (i % WIDTH as usize) as i16;
            let y = (i / WIDTH as usize) as i16;
            let inside = x >= self.box_x
                && x < self.box_x + BOX_SIZE
                && y >= self.box_y
                && y < self.box_y + BOX_SIZE;
            let rgba = if inside { [0x5e, 0x48, 0xe8, 0xff] } else { [0x48, 0xb2, 0xe8, 0xff] };
            px.copy_from_slice(&rgba);
        }
    }
}

fn log_error<E: std::error::Error + 'static>(method_name: &str, err: E) {
    error!("{method_name}() failed: {err}");
    for source in err.sources().skip(1) {
        error!("  Caused by: {source}");
    }
}

struct App {
    window: Option<&'static Window>,     // leaked &'static Window
    pixels: Option<Pixels<'static>>,     // borrows the window
    world: World,
}

impl App {
    fn new() -> Self {
        Self { window: None, pixels: None, world: World::new() }
    }
}

impl ApplicationHandler for App {
    fn resumed(&mut self, elwt: &ActiveEventLoop) {
        if self.window.is_none() {
            // Create window
            let size = LogicalSize::new(WIDTH as f64, HEIGHT as f64);
            let attrs = WindowAttributes::default()
                .with_title("Hello Pixels")
                .with_inner_size(size)
                .with_min_inner_size(size);
            let window = elwt.create_window(attrs).expect("create window");

            // Leak to get &'static Window so Pixels can live in the struct
            let window: &'static Window = Box::leak(Box::new(window));
            let win_size = window.inner_size();

            // Create Pixels
            let surface = SurfaceTexture::new(win_size.width, win_size.height, window);
            let pixels = Pixels::new(WIDTH, HEIGHT, surface).expect("create pixels");

            self.window = Some(window);
            self.pixels = Some(pixels);
        }
    }

    fn window_event(
        &mut self,
        elwt: &ActiveEventLoop,
        window_id: winit::window::WindowId,
        event: WindowEvent,
    ) {
        let Some(window) = self.window else { return };
        if window_id != window.id() { return; }

        match event {
            WindowEvent::CloseRequested => elwt.exit(),
            WindowEvent::KeyboardInput {
                event: KeyEvent {
                    physical_key: PhysicalKey::Code(KeyCode::Escape),
                    state: ElementState::Pressed,
                    ..
                },
                ..
            } => elwt.exit(),
            WindowEvent::Resized(size) => {
                if let Some(pixels) = self.pixels.as_mut() {
                    if let Err(err) = pixels.resize_surface(size.width, size.height) {
                        log_error("pixels.resize_surface", err);
                        elwt.exit();
                    }
                }
            }
            WindowEvent::RedrawRequested => {
                if let Some(pixels) = self.pixels.as_mut() {
                    self.world.draw(pixels.frame_mut());
                    if let Err(err) = pixels.render() {
                        log_error("pixels.render", err);
                        elwt.exit();
                    }
                }
            }
            _ => {}
        }
    }

    fn about_to_wait(&mut self, _elwt: &ActiveEventLoop) {
        if let Some(window) = self.window {
            self.world.update();
            window.request_redraw();
        }
    }
}

fn main() -> Result<(), Error> {
    env_logger::init();
    let event_loop = EventLoop::new().expect("create event loop");
    let mut app = App::new();
    let res = event_loop.run_app(&mut app);
    res.map_err(|e| Error::UserDefined(Box::new(e)))
}
```

## Notes
- `Box::leak` used to simplify `Pixels<'a>` lifetime.

# Example without leak
## main.rs
```rust
#![deny(clippy::all)]
// NOTE: Do NOT `forbid(unsafe_code)` here: ouroboros uses internal `unsafe`.

use error_iter::ErrorIter as _;
use log::error;
use ouroboros::self_referencing;
use pixels::{Error as PixelsError, Pixels, SurfaceTexture, wgpu};
use winit::application::ApplicationHandler;
use winit::dpi::LogicalSize;
use winit::event::{ElementState, KeyEvent, WindowEvent};
use winit::event_loop::{ActiveEventLoop, EventLoop};
use winit::keyboard::{KeyCode, PhysicalKey};
use winit::window::{Window, WindowAttributes};

const WIDTH: u32 = 320;
const HEIGHT: u32 = 240;
const BOX_SIZE: i16 = 64;

struct World {
    box_x: i16,
    box_y: i16,
    vx: i16,
    vy: i16,
}
impl World {
    fn new() -> Self { Self { box_x: 24, box_y: 16, vx: 1, vy: 1 } }
    fn update(&mut self) {
        if self.box_x <= 0 || self.box_x + BOX_SIZE > WIDTH as i16 { self.vx *= -1; }
        if self.box_y <= 0 || self.box_y + BOX_SIZE > HEIGHT as i16 { self.vy *= -1; }
        self.box_x += self.vx; self.box_y += self.vy;
    }
    fn draw(&self, frame: &mut [u8]) {
        for (i, px) in frame.chunks_exact_mut(4).enumerate() {
            let x = (i % WIDTH as usize) as i16;
            let y = (i / WIDTH as usize) as i16;
            let inside = x >= self.box_x && x < self.box_x + BOX_SIZE &&
                         y >= self.box_y && y < self.box_y + BOX_SIZE;
            let rgba = if inside { [0x5e, 0x48, 0xe8, 0xff] } else { [0x48, 0xb2, 0xe8, 0xff] };
            px.copy_from_slice(&rgba);
        }
    }
}

fn log_error<E: std::error::Error + 'static>(method_name: &str, err: E) {
    error!("{method_name}() failed: {err}");
    for source in err.sources().skip(1) { error!("  Caused by: {source}"); }
}

/// Owns Window and Pixels; Pixels borrows Window (no leaks).
#[self_referencing]
struct Gfx {
    window: Window,
    #[borrows(window)]
    #[covariant]
    pixels: Pixels<'this>,
}

struct App {
    gfx: Option<Gfx>,
    world: World,
}
impl App { fn new() -> Self { Self { gfx: None, world: World::new() } } }

impl ApplicationHandler for App {
    fn resumed(&mut self, elwt: &ActiveEventLoop) {
        if self.gfx.is_none() {
            let size = LogicalSize::new(WIDTH as f64, HEIGHT as f64);
            let attrs = WindowAttributes::default()
                .with_title("Hello Pixels")
                .with_inner_size(size)
                .with_min_inner_size(size);
            let window = elwt.create_window(attrs).expect("create window");

            self.gfx = Some(Gfx::new(window, |window| {
                let ws = window.inner_size();
                let surface = SurfaceTexture::new(ws.width, ws.height, window);
                Pixels::new(WIDTH, HEIGHT, surface).expect("create pixels")
            }));

            if let Some(gfx) = &self.gfx {
                gfx.with_window(|w| w.request_redraw()); // kick first frame
            }
        }
    }

    fn window_event(&mut self, elwt: &ActiveEventLoop, window_id: winit::window::WindowId, event: WindowEvent) {
        let Some(gfx) = self.gfx.as_mut() else { return; };
        if !gfx.with_window(|w| w.id() == window_id) { return; }

        match event {
            WindowEvent::CloseRequested => elwt.exit(),

            WindowEvent::KeyboardInput {
                event: KeyEvent {
                    physical_key: PhysicalKey::Code(KeyCode::Escape),
                    state: ElementState::Pressed, ..
                }, ..
            } => elwt.exit(),

            WindowEvent::Resized(size) => {
                gfx.with_pixels_mut(|p| {
                    if let Err(err) = p.resize_surface(size.width, size.height) {
                        log_error("pixels.resize_surface", err);
                        elwt.exit();
                    }
                });
            }

            WindowEvent::ScaleFactorChanged { .. } => {
                let inner = gfx.with_window(|w| w.inner_size());
                gfx.with_pixels_mut(|p| {
                    if let Err(err) = p.resize_surface(inner.width, inner.height) {
                        log_error("pixels.resize_surface (dpi)", err);
                        elwt.exit();
                    }
                });
            }

            WindowEvent::RedrawRequested => {
                // Gather window size BEFORE mutably borrowing pixels
                let win_size = gfx.with_window(|w| w.inner_size());
                if win_size.width == 0 || win_size.height == 0 { return; }

                // State for post-render actions (avoid nested borrows)
                let mut need_recover = false;
                let mut fatal_oom = false;
                let mut fatal_other: Option<PixelsError> = None;

                gfx.with_pixels_mut(|p| {
                    self.world.draw(p.frame_mut());
                    if let Err(err) = p.render() {
                        match err {
                            PixelsError::Surface(se) => match se {
                                wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated => {
                                    need_recover = true; // do resize after we release &mut p
                                }
                                wgpu::SurfaceError::OutOfMemory => fatal_oom = true,
                                wgpu::SurfaceError::Timeout => { /* skip this frame */ }
                            },
                            other => { fatal_other = Some(other); }
                        }
                    }
                });

                if let Some(other) = fatal_other {
                    log_error("pixels.render", other);
                    elwt.exit();
                    return;
                }
                if fatal_oom {
                    elwt.exit();
                    return;
                }
                if need_recover {
                    // Now it’s safe to borrow pixels again and resize using win_size
                    gfx.with_pixels_mut(|p| {
                        if let Err(e) = p.resize_surface(win_size.width, win_size.height) {
                            log_error("pixels.resize_surface (recover)", e);
                            elwt.exit();
                        }
                    });
                }
            }

            _ => {}
        }
    }

    fn about_to_wait(&mut self, _elwt: &ActiveEventLoop) {
        if let Some(gfx) = &self.gfx {
            self.world.update();
            gfx.with_window(|w| w.request_redraw());
        }
    }
}

fn main() -> Result<(), PixelsError> {
    env_logger::init();
    let event_loop = EventLoop::new().expect("create event loop");
    let mut app = App::new();
    event_loop.run_app(&mut app).map_err(|e| PixelsError::UserDefined(Box::new(e)))
}
```
## Cargo.toml
```toml
[package]
name = "minimal-winit"
version = "0.1.0"
edition = "2024"
publish = false

[features]
optimize = ["log/release_max_level_warn"]
default = ["optimize"]

[dependencies]
log = "0.4"
env_logger = "0.11"
error-iter = "0.4"
winit = "0.30"
pixels = "0.15"
ouroboros = "0.18"
```