### PR TITLE
Fix error when minimizing example windows

### DIFF
--- a/examples/conway/src/main.rs
+++ b/examples/conway/src/main.rs
@@ -129,6 +129,8 @@ fn main() -> Result<(), Error> {
                     }
                     // Resize the window
                     if let Some(size) = input.window_resized()
+                        && size.width > 0
+                        && size.height > 0
                         && let Err(err) = pixels.resize_surface(size.width, size.height)
                     {
                         log_error("pixels.resize_surface", err);

--- a/examples/custom-shader/src/main.rs
+++ b/examples/custom-shader/src/main.rs
@@ -75,7 +75,10 @@ fn main() -> Result<(), Error> {
                     }
 
                     // Resize the window
-                    if let Some(size) = input.window_resized() {
+                    if let Some(size) = input.window_resized()
+                        && size.width > 0
+                        && size.height > 0
+                    {
                         if let Err(err) = pixels.resize_surface(size.width, size.height) {
                             log_error("pixels.resize_surface", err);
                             elwt.exit();

--- a/examples/invaders/src/main.rs
+++ b/examples/invaders/src/main.rs
@@ -196,6 +196,8 @@ fn main() -> Result<(), Error> {
 
                         // Resize the window
                         if let Some(size) = g.game.input.window_resized()
+                            && size.width > 0
+                            && size.height > 0
                             && let Err(err) = g.game.pixels.resize_surface(size.width, size.height)
                             {
                                 log_error("pixels.resize_surface", err);

--- a/examples/minimal-egui/src/main.rs
+++ b/examples/minimal-egui/src/main.rs
@@ -94,7 +94,10 @@ fn main() -> Result<(), Error> {
                     }
 
                     // Resize the window
-                    if let Some(size) = input.window_resized() {
+                    if let Some(size) = input.window_resized()
+                        && size.width > 0
+                        && size.height > 0
+                    {
                         if let Err(err) = pixels.resize_surface(size.width, size.height) {
                             log_error("pixels.resize_surface", err);
                             event_loop.exit();

--- a/examples/minimal-tao/src/main.rs
+++ b/examples/minimal-tao/src/main.rs
@@ -103,7 +103,7 @@ fn main() -> Result<(), Error> {
                 }
 
                 // Resize the window
-                WindowEvent::Resized(size) => {
+                WindowEvent::Resized(size) if size.width > 0 && size.height > 0 => {
                     if let Err(err) = pixels.resize_surface(size.width, size.height) {
                         log_error("pixels.resize_surface", err);
                         *control_flow = ControlFlow::Exit;

--- a/examples/minimal-web/src/main.rs
+++ b/examples/minimal-web/src/main.rs
@@ -141,7 +141,10 @@ async fn run() {
             Event::WindowEvent { event, .. } => {
                 if let WindowEvent::Resized(size) = event {
                     // Resize the window
-                    if let Err(err) = pixels.resize_surface(size.width, size.height) {
+                    if size.width > 0
+                        && size.height > 0
+                        && let Err(err) = pixels.resize_surface(size.width, size.height)
+                    {
                         log_error("pixels.resize_surface", err);
                         elwt.exit();
                         return;

--- a/examples/minimal-winit-android/src/lib.rs
+++ b/examples/minimal-winit-android/src/lib.rs
@@ -61,7 +61,7 @@ pub fn _main(event_loop: EventLoop<()>) {
             Event::WindowEvent {
                 event: WindowEvent::Resized(size),
                 ..
-            } => {
+            } if size.width > 0 && size.height > 0 => {
                 if let Some(display) = &mut display {
                     display
                         .pixels

--- a/examples/minimal-winit/src/main.rs
+++ b/examples/minimal-winit/src/main.rs
@@ -71,6 +71,8 @@ fn main() -> Result<(), Error> {
 
                     // Resize the window
                     if let Some(size) = input.window_resized()
+                        && size.width > 0
+                        && size.height > 0
                         && let Err(err) = pixels.resize_surface(size.width, size.height)
                     {
                         log_error("pixels.resize_surface", err);

--- a/examples/raqote-winit/src/main.rs
+++ b/examples/raqote-winit/src/main.rs
@@ -70,6 +70,8 @@ fn main() -> Result<(), Error> {
 
                     // Resize the window
                     if let Some(size) = input.window_resized()
+                        && size.width > 0
+                        && size.height > 0
                         && let Err(err) = pixels.resize_surface(size.width, size.height)
                     {
                         log_error("pixels.resize_surface", err);

--- a/examples/tiny-skia-winit/src/main.rs
+++ b/examples/tiny-skia-winit/src/main.rs
@@ -68,6 +68,8 @@ fn main() -> Result<(), Error> {
 
                     // Resize the window
                     if let Some(size) = input.window_resized()
+                        && size.width > 0
+                        && size.height > 0
                         && let Err(err) = pixels.resize_surface(size.width, size.height)
                     {
                         log_error("pixels.resize_surface", err);


### PR DESCRIPTION
Most of the examples didn't have the size guard in the resize handler. This caused them to exit with an error on Windows when minimizing.