### PR TITLE
Drop surface before reconfiguring it if texture is Suboptimal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -556,9 +556,14 @@ impl<'win> Pixels<'win> {
             match self.context.surface.get_current_texture() {
                 CurrentSurfaceTexture::Success(surface_texture) => break surface_texture,
 
-                CurrentSurfaceTexture::Suboptimal(_)
-                | CurrentSurfaceTexture::Outdated
-                | CurrentSurfaceTexture::Lost => {
+                CurrentSurfaceTexture::Suboptimal(surface) => {
+                    // It's important to drop the current surface before reconfiguring it, otherwise
+                    // wgpu will panic.
+                    // see https://github.com/parasyte/pixels/issues/450
+                    drop(surface);
+                    self.reconfigure_surface();
+                }
+                CurrentSurfaceTexture::Outdated | CurrentSurfaceTexture::Lost => {
                     // Reconfigure the surface and retry immediately on any error.
                     // See https://github.com/parasyte/pixels/issues/121
                     // See https://github.com/parasyte/pixels/issues/346


### PR DESCRIPTION
Apply the same fix as https://github.com/gfx-rs/wgpu/pull/9384

closes: #450