### PR TITLE
Keep window handle alive

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -19,8 +19,9 @@ pub struct PixelsBuilder<'req, 'dev, 'win, W: wgpu::WindowHandle + 'win> {
     alpha_mode: wgpu::CompositeAlphaMode,
 }
 
-impl<'req, 'dev, 'win, W: wgpu::WindowHandle + raw_window_handle::HasDisplayHandle + 'win>
-    PixelsBuilder<'req, 'dev, 'win, W>
+impl<'req, 'dev, 'win, W> PixelsBuilder<'req, 'dev, 'win, W>
+where
+    W: Clone + wgpu::WindowHandle + raw_window_handle::HasDisplayHandle + 'win,
 {
     /// Create a builder that can be finalized into a [`Pixels`] pixel buffer.
     ///
@@ -269,14 +270,14 @@ impl<'req, 'dev, 'win, W: wgpu::WindowHandle + raw_window_handle::HasDisplayHand
     /// # Errors
     ///
     /// Returns an error when a [`wgpu::Adapter`] cannot be found.
-    async fn build_impl(self) -> Result<Pixels<'win>, Error> {
+    async fn build_impl(self) -> Result<Pixels<'win, W>, Error> {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: self.backend,
             ..wgpu::InstanceDescriptor::new_without_display_handle().with_env()
         });
 
         // TODO: Use `options.pixel_aspect_ratio` to stretch the scaled texture
-        let surface = instance.create_surface(self.surface_texture.window)?;
+        let surface = instance.create_surface(self.surface_texture.window.clone())?;
         let compatible_surface = Some(&surface);
         let request_adapter_options = &self.request_adapter_options;
         let adapter = match wgpu::util::initialize_adapter_from_env(&instance, compatible_surface)
@@ -380,6 +381,7 @@ impl<'req, 'dev, 'win, W: wgpu::WindowHandle + raw_window_handle::HasDisplayHand
         let alpha_mode = self.alpha_mode;
         let pixels = Pixels {
             context,
+            _window: self.surface_texture.window,
             adapter,
             surface_size,
             present_mode,
@@ -404,7 +406,7 @@ impl<'req, 'dev, 'win, W: wgpu::WindowHandle + raw_window_handle::HasDisplayHand
     ///
     /// Returns an error when a [`wgpu::Adapter`] or [`wgpu::Device`] cannot be found.
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn build(self) -> Result<Pixels<'win>, Error> {
+    pub fn build(self) -> Result<Pixels<'win, W>, Error> {
         pollster::block_on(self.build_impl())
     }
 
@@ -430,7 +432,7 @@ impl<'req, 'dev, 'win, W: wgpu::WindowHandle + raw_window_handle::HasDisplayHand
     /// # Errors
     ///
     /// Returns an error when a [`wgpu::Adapter`] or [`wgpu::Device`] cannot be found.
-    pub async fn build_async(self) -> Result<Pixels<'win>, Error> {
+    pub async fn build_async(self) -> Result<Pixels<'win, W>, Error> {
         self.build_impl().await
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,8 +106,9 @@ pub struct PixelsContext<'win> {
 ///
 /// See [`PixelsBuilder`] for building a customized pixel buffer.
 #[derive(Debug)]
-pub struct Pixels<'win> {
+pub struct Pixels<'win, W: 'win> {
     context: PixelsContext<'win>,
+    _window: W,
     surface_size: SurfaceSize,
     present_mode: wgpu::PresentMode,
     render_texture_format: wgpu::TextureFormat,
@@ -199,7 +200,10 @@ impl<W: wgpu::WindowHandle> SurfaceTexture<W> {
     }
 }
 
-impl<'win> Pixels<'win> {
+impl<'win, W> Pixels<'win, W>
+where
+    W: Clone + wgpu::WindowHandle + raw_window_handle::HasDisplayHandle + 'win,
+{
     /// Create a pixel buffer instance with default options.
     ///
     /// Any ratio differences between the pixel buffer texture size and surface texture size will
@@ -222,7 +226,7 @@ impl<'win> Pixels<'win> {
     /// # use pixels::{Pixels, SurfaceTexture};
     /// # let window = pixels_mocks::Window;
     /// let surface_texture = SurfaceTexture::new(320, 240, &window);
-    /// let mut pixels: Pixels<'_> = Pixels::new(320, 240, surface_texture)?;
+    /// let mut pixels: Pixels<'_, _> = Pixels::new(320, 240, surface_texture)?;
     /// # Ok::<(), pixels::Error>(())
     /// ```
     ///
@@ -235,7 +239,7 @@ impl<'win> Pixels<'win> {
     /// # let window = pixels_mocks::Window;
     /// let arc = Arc::new(window);
     /// let surface_texture = SurfaceTexture::new(320, 240, arc.clone());
-    /// let mut pixels: Pixels<'static> = Pixels::new(320, 240, surface_texture)?;
+    /// let mut pixels: Pixels<'static, _> = Pixels::new(320, 240, surface_texture)?;
     /// # Ok::<(), pixels::Error>(())
     /// ```
     ///
@@ -247,11 +251,7 @@ impl<'win> Pixels<'win> {
     ///
     /// Panics when `width` or `height` are 0.
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn new<W: wgpu::WindowHandle + raw_window_handle::HasDisplayHandle + 'win>(
-        width: u32,
-        height: u32,
-        surface_texture: SurfaceTexture<W>,
-    ) -> Result<Self, Error> {
+    pub fn new(width: u32, height: u32, surface_texture: SurfaceTexture<W>) -> Result<Self, Error> {
         PixelsBuilder::new(width, height, surface_texture).build()
     }
 
@@ -278,7 +278,7 @@ impl<'win> Pixels<'win> {
     /// # Panics
     ///
     /// Panics when `width` or `height` are 0.
-    pub async fn new_async<W: wgpu::WindowHandle + raw_window_handle::HasDisplayHandle + 'win>(
+    pub async fn new_async(
         width: u32,
         height: u32,
         surface_texture: SurfaceTexture<W>,


### PR DESCRIPTION
This fixes a potential panic that can occur with specific struct layouts due to Rust drop order.

It was discovered and discussed in #454, and is related to https://github.com/gfx-rs/wgpu/pull/6997

This is a breaking change. It adds a new `W: 'win` generic parameter to the `Pixels` struct so that the window handle that the surface is attached to is guaranteed to remain alive while the `Surface<'win>` is held.