### PR TITLE
Bound surface reconfiguration retries

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,12 +146,32 @@ pub enum Error {
     /// User-defined error from custom render function
     #[error("User-defined error.")]
     UserDefined(#[from] DynError),
+    /// Surface acquisition still failed after reconfiguration
+    #[error("The GPU failed to acquire a surface frame.")]
+    Surface,
     /// wgpu validation error
     #[error("wgpu validation error")]
     Validation,
 }
 
 type DynError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+// This matches the bounded recovery behavior from before wgpu 29 replaced `SurfaceError` with
+// `CurrentSurfaceTexture`.
+const MAX_SURFACE_RECONFIGURATIONS: usize = 1;
+
+fn retry_surface_acquisition(
+    reconfigurations: &mut usize,
+    reconfigure: impl FnOnce(),
+) -> Result<(), Error> {
+    if *reconfigurations >= MAX_SURFACE_RECONFIGURATIONS {
+        return Err(Error::Surface);
+    }
+
+    *reconfigurations += 1;
+    reconfigure();
+    Ok(())
+}
 
 /// All the ways in which creating a texture can fail.
 #[derive(Error, Debug)]
@@ -552,6 +572,7 @@ impl<'win> Pixels<'win> {
             &PixelsContext,
         ) -> Result<(), DynError>,
     {
+        let mut reconfigurations = 0;
         let frame = loop {
             match self.context.surface.get_current_texture() {
                 CurrentSurfaceTexture::Success(surface_texture) => break surface_texture,
@@ -561,13 +582,17 @@ impl<'win> Pixels<'win> {
                     // wgpu will panic.
                     // see https://github.com/parasyte/pixels/issues/450
                     drop(surface);
-                    self.reconfigure_surface();
+                    retry_surface_acquisition(&mut reconfigurations, || {
+                        self.reconfigure_surface();
+                    })?;
                 }
                 CurrentSurfaceTexture::Outdated | CurrentSurfaceTexture::Lost => {
-                    // Reconfigure the surface and retry immediately on any error.
+                    // Reconfigure the surface and retry immediately once.
                     // See https://github.com/parasyte/pixels/issues/121
                     // See https://github.com/parasyte/pixels/issues/346
-                    self.reconfigure_surface();
+                    retry_surface_acquisition(&mut reconfigurations, || {
+                        self.reconfigure_surface();
+                    })?;
                 }
 
                 CurrentSurfaceTexture::Occluded | CurrentSurfaceTexture::Timeout => return Ok(()),
@@ -771,5 +796,23 @@ impl<'win> Pixels<'win> {
     /// See [`PixelsBuilder::render_texture_format`] for more information.
     pub fn render_texture_format(&self) -> wgpu::TextureFormat {
         self.render_texture_format
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Error, retry_surface_acquisition};
+
+    #[test]
+    fn surface_reconfiguration_is_bounded() {
+        let mut attempts = 0;
+        let mut reconfigurations = 0;
+
+        retry_surface_acquisition(&mut attempts, || reconfigurations += 1).unwrap();
+        assert_eq!(reconfigurations, 1);
+
+        let result = retry_surface_acquisition(&mut attempts, || reconfigurations += 1);
+        assert!(matches!(result, Err(Error::Surface)));
+        assert_eq!(reconfigurations, 1);
     }
 }


### PR DESCRIPTION
Closes #460.

A persistent `Suboptimal`, `Outdated`, or `Lost` result currently reconfigures the surface and re-enters an unconditional loop. If reconfiguration cannot correct the status—such as while the cached size is stale—`render_with` never returns and the event loop cannot deliver the resize that would recover it.

This restores the bounded behavior from before the wgpu 29 update:

- reconfigure and retry acquisition once;
- return `Error::Surface` if a recoverable status persists;
- retain the existing skip behavior for `Occluded`/`Timeout` and validation error handling;
- regression-test that only one reconfiguration is performed before returning the error.

Validation:

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo doc --workspace --no-deps`
- `cargo clippy --workspace --tests -- -D warnings`
- `cargo test --workspace`
- CI-equivalent WASM and Android `cargo check`/Clippy commands for all three cross targets
- `git diff --check`

The Linux/X11 driver hang is not available on this macOS host; the source-level failure is deterministic, and the regression exercises the bounded recovery policy without requiring a real GPU surface.